### PR TITLE
docs: Add Google-style docstrings to analysis_tools.py

### DIFF
--- a/kicad_mcp/tools/analysis_tools.py
+++ b/kicad_mcp/tools/analysis_tools.py
@@ -1,25 +1,60 @@
 """
 Analysis and validation tools for KiCad projects.
+
+This module provides utility functions that can be registered with the FastMCP
+server to analyze and validate the structure and contents of KiCad projects.
+
+Functions:
+    - register_analysis_tools: Registers analysis functions like project validation.
+
+Usage:
+    This module is intended to be used by the MCP server via tool registration.
 """
 
 import os
 from typing import Any
 
 from fastmcp import FastMCP
-
 from kicad_mcp.utils.file_utils import get_project_files
 
 
 def register_analysis_tools(mcp: FastMCP) -> None:
-    """Register analysis and validation tools with the MCP server.
+    """
+    Register analysis and validation tools with the MCP server.
 
     Args:
-        mcp: The FastMCP server instance
-    """
+        mcp (FastMCP): The FastMCP server instance.
 
+    Returns:
+        None
+    """
     @mcp.tool()
     def validate_project(project_path: str) -> dict[str, Any]:
-        """Basic validation of a KiCad project."""
+        """
+        Perform basic validation of a KiCad project directory.
+
+        This tool checks whether the provided project directory exists,
+        and whether it contains expected KiCad files like PCB and schematic.
+
+        It also attempts to open and parse the main project file to ensure
+        it's in valid JSON format.
+
+        Args:
+            project_path (str): Path to the KiCad project file (usually `.kicad_pro`).
+
+        Returns:
+            dict[str, Any]: A dictionary containing:
+                - valid (bool): Whether the project is considered valid.
+                - path (str): The path of the project.
+                - issues (list[str] | None): List of issues found, or None if valid.
+                - files_found (list[str]): Keys of detected project files.
+
+        Raises:
+            This function handles exceptions internally and does not raise errors.
+
+        Time Complexity:
+            O(n) where n is the number of files in the project directory.
+        """
         if not os.path.exists(project_path):
             return {"valid": False, "error": f"Project not found: {project_path}"}
 
@@ -33,11 +68,10 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         if "schematic" not in files:
             issues.append("Missing schematic file")
 
-        # Validate project file
+        # Validate project file format
         try:
             with open(project_path) as f:
                 import json
-
                 json.load(f)
         except json.JSONDecodeError:
             issues.append("Invalid project file format (JSON parsing error)")


### PR DESCRIPTION
This PR adds comprehensive Google-style docstrings to `analysis_tools.py`, including:
- Module-level description and purpose.
- Function-level documentation for `register_analysis_tools` and `validate_project`.
- Clear type annotations and return value structure.
- Usage context and time complexity.

This improves code readability and developer experience when integrating new tools.
