### PR TITLE
fix(security): resolve B607 subprocess security issues in DRC CLI

### DIFF
--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -4,6 +4,7 @@ Design Rule Check (DRC) implementation using KiCad command-line interface.
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 from typing import Any
@@ -112,18 +113,18 @@ def find_kicad_cli() -> str | None:
     Returns:
         Path to kicad-cli if found, None otherwise
     """
-    # Check if kicad-cli is in PATH
+    # Check if kicad-cli is in PATH using shutil.which() for security
     try:
         if system == "Windows":
             # On Windows, check for kicad-cli.exe
-            result = subprocess.run(["where", "kicad-cli.exe"], capture_output=True, text=True)
-            if result.returncode == 0:
-                return result.stdout.strip().split("\n")[0]
+            kicad_path = shutil.which("kicad-cli.exe")
+            if kicad_path:
+                return kicad_path
         else:
-            # On Unix-like systems, use which
-            result = subprocess.run(["which", "kicad-cli"], capture_output=True, text=True)
-            if result.returncode == 0:
-                return result.stdout.strip()
+            # On Unix-like systems, check for kicad-cli
+            kicad_path = shutil.which("kicad-cli")
+            if kicad_path:
+                return kicad_path
 
     except Exception as e:
         print(f"Error finding kicad-cli: {str(e)}")


### PR DESCRIPTION
## Summary

Fixes the B607 security vulnerabilities identified by Bandit in PR #35 by replacing unsafe subprocess calls with secure alternatives.

- **Issue**: Bandit flagged 2 LOW severity B607 issues for "Starting a process with a partial executable path"
- **Files affected**: `kicad_mcp/tools/drc_impl/cli_drc.py` (lines 119, 124)  
- **Solution**: Replace `subprocess.run()` calls with `shutil.which()` for KiCad CLI detection

## Changes Made

- ✅ Added `shutil` import 
- ✅ Replaced `subprocess.run(["where", "kicad-cli.exe"], ...)` with `shutil.which("kicad-cli.exe")`
- ✅ Replaced `subprocess.run(["which", "kicad-cli"], ...)` with `shutil.which("kicad-cli")`
- ✅ Updated error handling logic for `shutil.which()` return values

## Benefits

- 🔒 **More secure**: Eliminates command injection risks (B607 vulnerabilities)
- 🌐 **More portable**: Consistent behavior across Windows/Unix systems  
- ⚡ **Better performance**: No subprocess overhead
- 🎯 **Maintains functionality**: All existing behavior preserved

## Testing

- ✅ **Security scan**: `bandit` reports "No issues identified" 
- ✅ **Linting**: All `ruff` checks pass
- ✅ **Test suite**: All 362 tests passing
- ✅ **Pre-commit hooks**: All validation passes

## Verification

Before:
```
Test results:
	Total issues (by severity):
		Low: 2
```

After:  
```
Test results:
	No issues identified.
```

🤖 Generated with [Claude Code](https://claude.ai/code)