### PR TITLE
fix(security): redact env logs and migrate to SecureSubprocessRunner

### DIFF
--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -640,69 +640,28 @@ async def export_bom_with_cli(
     Returns:
         Dictionary with export results
     """
-    import platform
-    import subprocess
+    from kicad_mcp.utils.kicad_cli import KiCadCLIError
+    from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
-    system = platform.system()
-    print(f"Exporting BOM using CLI tools on {system}")
+    print("Exporting BOM using CLI tools via SecureSubprocessRunner")
     await ctx.report_progress(40, 100)
 
     # Output file path
     output_file = os.path.join(output_dir, f"{project_name}_bom.csv")
 
-    # Define the command based on operating system
-    if system == "Darwin":  # macOS
-        from kicad_mcp.config import KICAD_APP_PATH
-
-        # Path to KiCad command-line tools on macOS
-        kicad_cli = os.path.join(KICAD_APP_PATH, "Contents/MacOS/kicad-cli")
-
-        if not os.path.exists(kicad_cli):
-            return {
-                "success": False,
-                "error": f"KiCad CLI tool not found at {kicad_cli}",
-                "schematic_file": schematic_file,
-            }
-
-        # Command to generate BOM
-        cmd = [kicad_cli, "sch", "export", "bom", "--output", output_file, schematic_file]
-
-    elif system == "Windows":
-        from kicad_mcp.config import KICAD_APP_PATH
-
-        # Path to KiCad command-line tools on Windows
-        kicad_cli = os.path.join(KICAD_APP_PATH, "bin", "kicad-cli.exe")
-
-        if not os.path.exists(kicad_cli):
-            return {
-                "success": False,
-                "error": f"KiCad CLI tool not found at {kicad_cli}",
-                "schematic_file": schematic_file,
-            }
-
-        # Command to generate BOM
-        cmd = [kicad_cli, "sch", "export", "bom", "--output", output_file, schematic_file]
-
-    elif system == "Linux":
-        # Assume kicad-cli is in the PATH
-        kicad_cli = "kicad-cli"
-
-        # Command to generate BOM
-        cmd = [kicad_cli, "sch", "export", "bom", "--output", output_file, schematic_file]
-
-    else:
-        return {
-            "success": False,
-            "error": f"Unsupported operating system: {system}",
-            "schematic_file": schematic_file,
-        }
+    # Command args (without kicad-cli executable - SecureSubprocessRunner resolves it)
+    command_args = ["sch", "export", "bom", "--output", output_file, schematic_file]
 
     try:
-        print(f"Running command: {' '.join(cmd)}")
+        print("Running BOM export command via SecureSubprocessRunner")
         await ctx.report_progress(60, 100)
 
-        # Run the command
-        process = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        runner = get_subprocess_runner()
+        process = runner.run_kicad_command(
+            command_args=command_args,
+            input_files=[schematic_file],
+            output_files=[output_file],
+        )
 
         # Check if the command was successful
         if process.returncode != 0:
@@ -713,7 +672,6 @@ async def export_bom_with_cli(
                 "success": False,
                 "error": f"BOM export command failed: {process.stderr}",
                 "schematic_file": schematic_file,
-                "command": " ".join(cmd),
             }
 
         # Check if the output file was created
@@ -747,11 +705,11 @@ async def export_bom_with_cli(
             "message": "BOM exported successfully",
         }
 
-    except subprocess.TimeoutExpired:
-        print("BOM export command timed out after 30 seconds")
+    except (SecureSubprocessError, KiCadCLIError) as e:
+        print(f"BOM export command failed: {e}")
         return {
             "success": False,
-            "error": "BOM export command timed out after 30 seconds",
+            "error": f"BOM export command failed: {e}",
             "schematic_file": schematic_file,
         }
 

--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -4,14 +4,13 @@ Design Rule Check (DRC) implementation using KiCad command-line interface.
 
 import json
 import os
-import shutil
-import subprocess
 import tempfile
 from typing import Any
 
 from fastmcp import Context
 
-from kicad_mcp.config import system
+from kicad_mcp.utils.kicad_cli import KiCadCLIError, find_kicad_cli
+from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
 
 async def run_drc_via_cli(pcb_file: str, ctx: Context) -> dict[str, Any]:
@@ -45,11 +44,21 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context) -> dict[str, Any]:
             await ctx.report_progress(50, 100)
             ctx.info("Running DRC using KiCad CLI...")
 
-            # Build the DRC command
-            cmd = [kicad_cli, "pcb", "drc", "--format", "json", "--output", output_file, pcb_file]
+            # Build the DRC command args (without kicad-cli executable)
+            command_args = ["pcb", "drc", "--format", "json", "--output", output_file, pcb_file]
 
-            print(f"Running command: {' '.join(cmd)}")
-            process = subprocess.run(cmd, capture_output=True, text=True)
+            print("Running DRC command via SecureSubprocessRunner")
+            try:
+                runner = get_subprocess_runner()
+                process = runner.run_kicad_command(
+                    command_args=command_args,
+                    input_files=[pcb_file],
+                    output_files=[output_file],
+                )
+            except (SecureSubprocessError, KiCadCLIError) as e:
+                print(f"DRC command failed: {e}")
+                results["error"] = f"DRC command failed: {e}"
+                return results
 
             # Check if the command was successful
             if process.returncode != 0:
@@ -105,56 +114,3 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context) -> dict[str, Any]:
         print(f"Error in CLI DRC: {str(e)}", exc_info=True)
         results["error"] = f"Error in CLI DRC: {str(e)}"
         return results
-
-
-def find_kicad_cli() -> str | None:
-    """Find the kicad-cli executable in the system PATH.
-
-    Returns:
-        Path to kicad-cli if found, None otherwise
-    """
-    # Check if kicad-cli is in PATH using shutil.which() for security
-    try:
-        if system == "Windows":
-            # On Windows, check for kicad-cli.exe
-            kicad_path = shutil.which("kicad-cli.exe")
-            if kicad_path:
-                return kicad_path
-        else:
-            # On Unix-like systems, check for kicad-cli
-            kicad_path = shutil.which("kicad-cli")
-            if kicad_path:
-                return kicad_path
-
-    except Exception as e:
-        print(f"Error finding kicad-cli: {str(e)}")
-
-    # If we get here, kicad-cli is not in PATH
-    # Try common installation locations
-    if system == "Windows":
-        # Common Windows installation path
-        potential_paths = [
-            r"C:\Program Files\KiCad\bin\kicad-cli.exe",
-            r"C:\Program Files (x86)\KiCad\bin\kicad-cli.exe",
-        ]
-    elif system == "Darwin":  # macOS
-        # Common macOS installation paths
-        potential_paths = [
-            "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-            "/Applications/KiCad/kicad-cli",
-        ]
-    else:  # Linux and other Unix-like systems
-        # Common Linux installation paths
-        potential_paths = [
-            "/usr/bin/kicad-cli",
-            "/usr/local/bin/kicad-cli",
-            "/opt/kicad/bin/kicad-cli",
-        ]
-
-    # Check each potential path
-    for path in potential_paths:
-        if os.path.exists(path) and os.access(path, os.X_OK):
-            return path
-
-    # If still not found, return None
-    return None

--- a/kicad_mcp/tools/visualization_tools.py
+++ b/kicad_mcp/tools/visualization_tools.py
@@ -5,13 +5,14 @@ Provides screenshot and rendering capabilities for debugging and testing.
 
 import io
 import os
-import subprocess
 from typing import Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.utilities.types import Image
 
 from kicad_mcp.utils.file_utils import get_project_files
+from kicad_mcp.utils.kicad_cli import KiCadCLIError, find_kicad_cli
+from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
 
 def register_visualization_tools(mcp: FastMCP) -> None:
@@ -204,23 +205,8 @@ async def export_schematic_to_svg(
         Dictionary with export results
     """
     try:
-        # Check if kicad-cli is available (try macOS path first)
-        kicad_cli_paths = [
-            "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-            "kicad-cli",  # fallback to PATH
-        ]
-
-        kicad_cli = None
-        for cli_path in kicad_cli_paths:
-            try:
-                result = subprocess.run(
-                    [cli_path, "--version"], capture_output=True, text=True, timeout=10
-                )
-                if result.returncode == 0:
-                    kicad_cli = cli_path
-                    break
-            except FileNotFoundError:
-                continue
+        # Check if kicad-cli is available via centralized detection
+        kicad_cli = find_kicad_cli()
 
         if kicad_cli is None:
             # Fallback to mock renderer
@@ -229,9 +215,8 @@ async def export_schematic_to_svg(
 
         await ctx.report_progress(25, 100)
 
-        # Export schematic to SVG
-        cmd = [
-            kicad_cli,
+        # Export schematic to SVG via SecureSubprocessRunner
+        command_args = [
             "sch",
             "export",
             "svg",
@@ -242,9 +227,13 @@ async def export_schematic_to_svg(
             schematic_file,
         ]
 
-        await ctx.info(f"Running: {' '.join(cmd)}")
+        await ctx.info("Running schematic SVG export via SecureSubprocessRunner")
 
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        runner = get_subprocess_runner()
+        result = runner.run_kicad_command(
+            command_args=command_args,
+            input_files=[schematic_file],
+        )
 
         await ctx.report_progress(75, 100)
 
@@ -277,8 +266,8 @@ async def export_schematic_to_svg(
                 "command_error": result.stderr,
             }
 
-    except subprocess.TimeoutExpired:
-        return {"success": False, "error": "kicad-cli export timed out"}
+    except (SecureSubprocessError, KiCadCLIError) as e:
+        return {"success": False, "error": f"kicad-cli export failed: {e}"}
     except Exception as e:
         return {"success": False, "error": f"Unexpected error during SVG export: {str(e)}"}
 

--- a/kicad_mcp/utils/env.py
+++ b/kicad_mcp/utils/env.py
@@ -45,7 +45,7 @@ def load_dotenv(env_file: str = ".env") -> dict[str, str]:
                     key, value = line.split("=", 1)
                     key = key.strip()
                     value = value.strip()
-                    logging.debug(f"Parsed line {line_num}: Key='{key}', RawValue='{value}'")
+                    logging.debug(f"Parsed line {line_num}: Key='{key}', RawValue='***'")
 
                     # Remove quotes if present
                     if (
@@ -66,7 +66,7 @@ def load_dotenv(env_file: str = ".env") -> dict[str, str]:
                             )
 
                     # Set environment variable
-                    logging.info(f"Setting os.environ['{key}'] = '{value}'")
+                    logging.info(f"Setting os.environ['{key}'] = '***'")
                     os.environ[key] = value
                     env_vars[key] = value
                 else:
@@ -77,7 +77,7 @@ def load_dotenv(env_file: str = ".env") -> dict[str, str]:
         # Use logging.exception to include traceback
         logging.exception(f"Error loading .env file '{env_path}'")
 
-    logging.info(f"load_dotenv returning: {env_vars}")
+    logging.info(f"load_dotenv returning keys: {list(env_vars.keys())}")
     return env_vars
 
 

--- a/kicad_mcp/utils/kicad_api_detection.py
+++ b/kicad_mcp/utils/kicad_api_detection.py
@@ -4,9 +4,9 @@ Utility functions for detecting and selecting available KiCad API approaches.
 
 import os
 import shutil
-import subprocess
 
 from kicad_mcp.config import system
+from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
 
 def check_for_cli_api() -> bool:
@@ -26,12 +26,17 @@ def check_for_cli_api() -> bool:
 
         if kicad_cli:
             # Verify it's a working kicad-cli
-            cmd = [kicad_cli, "--version"] if system == "Windows" else [kicad_cli, "--version"]
-
-            result = subprocess.run(cmd, capture_output=True, text=True)
-            if result.returncode == 0:
-                print(f"Found working kicad-cli: {kicad_cli}")
-                return True
+            try:
+                runner = get_subprocess_runner()
+                result = runner.run_safe_command(
+                    [kicad_cli, "--version"],
+                    allowed_commands=[kicad_cli],
+                )
+                if result.returncode == 0:
+                    print(f"Found working kicad-cli: {kicad_cli}")
+                    return True
+            except SecureSubprocessError:
+                pass
 
         # Check common installation locations if not found in PATH
         if system == "Windows":


### PR DESCRIPTION
## Summary

- Redact sensitive environment variable values in `kicad_mcp/utils/env.py` log statements — only keys are logged, values are replaced with `***`
- Migrate all `subprocess.run()` calls outside `secure_subprocess.py` to use `SecureSubprocessRunner` with proper input validation, path checking, and timeout enforcement
- Remove duplicated `find_kicad_cli()` in `cli_drc.py` in favor of the centralized `kicad_mcp.utils.kicad_cli` module
- Remove platform-specific kicad-cli detection logic in `bom_tools.py` — `SecureSubprocessRunner.run_kicad_command()` handles CLI resolution

### Files changed

| File | Change |
|------|--------|
| `kicad_mcp/utils/env.py` | Redact values in 3 log statements |
| `kicad_mcp/tools/drc_impl/cli_drc.py` | Migrate to `run_kicad_command()`, remove local `find_kicad_cli()` |
| `kicad_mcp/utils/kicad_api_detection.py` | Migrate to `run_safe_command()` |
| `kicad_mcp/tools/bom_tools.py` | Migrate to `run_kicad_command()`, remove platform-specific CLI detection |
| `kicad_mcp/tools/visualization_tools.py` | Migrate to `run_kicad_command()` and `find_kicad_cli()` |

### Verification

After this change, only `secure_subprocess.py` and `kicad_cli.py` (internal validation with `nosec` annotations) contain direct `subprocess.run()` calls.

## Test plan

- [x] All 360 tests pass (`uv run pytest tests/ -v`)
- [x] `rg 'subprocess\.run' kicad_mcp/` confirms only `secure_subprocess.py` and `kicad_cli.py` retain direct calls
- [x] Lint passes (`uv run ruff check .`)
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)