### PR TITLE
ci: add Claude Code workflows and plugin permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,5 +22,26 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git branch *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git remote *)",
+      "Bash(git checkout *)",
+      "Bash(git fetch *)",
+      "Bash(gh pr *)",
+      "Bash(gh run *)",
+      "Bash(gh issue *)",
+      "Bash(pre-commit *)",
+      "Bash(gitleaks *)",
+      "mcp__context7",
+      "mcp__sequential-thinking"
+    ]
   }
 }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,17 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: laurigates/.github/.github/workflows/reusable-claude-review.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      plugin_marketplaces: |
+        https://github.com/laurigates/claude-plugins.git
+      plugins: |
+        code-quality-plugin@laurigates-claude-plugins
+        testing-plugin@laurigates-claude-plugins

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,25 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    uses: laurigates/.github/.github/workflows/reusable-claude.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      plugin_marketplaces: |
+        https://github.com/laurigates/claude-plugins.git
+      plugins: |
+        git-plugin@laurigates-claude-plugins
+        python-plugin@laurigates-claude-plugins
+        testing-plugin@laurigates-claude-plugins
+        code-quality-plugin@laurigates-claude-plugins


### PR DESCRIPTION
## Summary
- Add Claude Code GitHub Actions workflows using reusable workflows from `laurigates/.github`
- Configure `claude.yml` for @claude mentions (issues, PRs, review comments) with `laurigates/claude-plugins` marketplace
- Configure `claude-code-review.yml` for automatic PR reviews with code-quality and testing plugins
- Add tool permissions to `.claude/settings.json` for git, gh, pre-commit, gitleaks, and MCP tools

## Follow-up
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` to repository secrets (Settings > Secrets and variables > Actions)

## Test plan
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Test @claude mention in a PR comment triggers the workflow
- [ ] Test PR review workflow triggers on new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)