### PR TITLE
fix: clean up dead code in drc_tools and remove export_bom_with_python stub

### DIFF
--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -178,10 +178,6 @@ def register_bom_tools(mcp: FastMCP) -> None:
             await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
-        # Get access to the app context
-        app_context = ctx.request_context.lifespan_context
-        kicad_modules_available = app_context.kicad_modules_available
-
         # Report progress
         await ctx.report_progress(10, 100)
 
@@ -201,33 +197,17 @@ def register_bom_tools(mcp: FastMCP) -> None:
         await ctx.report_progress(20, 100)
         await ctx.info(f"Found schematic file: {os.path.basename(schematic_file)}")
 
-        # Try to export BOM
-        # This will depend on KiCad's command-line tools or Python modules
+        # Export BOM using command-line tools
         export_result = {"success": False}
-
-        if kicad_modules_available:
-            try:
-                # Try to use KiCad Python modules
-                await ctx.info("Attempting to export BOM using KiCad Python modules...")
-                export_result = await export_bom_with_python(
-                    schematic_file, project_dir, project_name, ctx
-                )
-            except Exception as e:
-                print(f"Error exporting BOM with Python modules: {str(e)}", exc_info=True)
-                await ctx.info(f"Error using Python modules: {str(e)}")
-                export_result = {"success": False, "error": str(e)}
-
-        # If Python method failed, try command-line method
-        if not export_result.get("success", False):
-            try:
-                await ctx.info("Attempting to export BOM using command-line tools...")
-                export_result = await export_bom_with_cli(
-                    schematic_file, project_dir, project_name, ctx
-                )
-            except Exception as e:
-                print(f"Error exporting BOM with CLI: {str(e)}", exc_info=True)
-                await ctx.info(f"Error using command-line tools: {str(e)}")
-                export_result = {"success": False, "error": str(e)}
+        try:
+            await ctx.info("Attempting to export BOM using command-line tools...")
+            export_result = await export_bom_with_cli(
+                schematic_file, project_dir, project_name, ctx
+            )
+        except Exception as e:
+            print(f"Error exporting BOM with CLI: {str(e)}", exc_info=True)
+            await ctx.info(f"Error using command-line tools: {str(e)}")
+            export_result = {"success": False, "error": str(e)}
 
         await ctx.report_progress(100, 100)
 
@@ -583,47 +563,6 @@ def analyze_bom_data(
         results["total_component_count"] = len(components)
 
     return results
-
-
-async def export_bom_with_python(
-    schematic_file: str, output_dir: str, project_name: str, ctx: Context
-) -> dict[str, Any]:
-    """Export a BOM using KiCad Python modules.
-
-    Args:
-        schematic_file: Path to the schematic file
-        output_dir: Directory to save the BOM
-        project_name: Name of the project
-        ctx: MCP context for progress reporting
-
-    Returns:
-        Dictionary with export results
-    """
-    print(f"Exporting BOM for schematic: {schematic_file}")
-    await ctx.report_progress(30, 100)
-
-    try:
-        # Try to import KiCad Python modules
-        # This is a placeholder since exporting BOMs from schematic files
-        # is complex and KiCad's API for this is not well-documented
-
-        # For now, return a message indicating this method is not implemented yet
-        print("BOM export with Python modules not fully implemented")
-        await ctx.info("BOM export with Python modules not fully implemented yet")
-
-        return {
-            "success": False,
-            "error": "BOM export using Python modules is not fully implemented yet. Try using the command-line method.",
-            "schematic_file": schematic_file,
-        }
-
-    except ImportError:
-        print("Failed to import KiCad Python modules")
-        return {
-            "success": False,
-            "error": "Failed to import KiCad Python modules",
-            "schematic_file": schematic_file,
-        }
 
 
 async def export_bom_with_cli(

--- a/kicad_mcp/tools/drc_tools.py
+++ b/kicad_mcp/tools/drc_tools.py
@@ -3,8 +3,6 @@ Design Rule Check (DRC) tools for KiCad PCB files.
 """
 
 import os
-
-# import logging # <-- Remove if no other logging exists
 from typing import Any
 
 from fastmcp import Context, FastMCP
@@ -100,13 +98,10 @@ def register_drc_tools(mcp: FastMCP) -> None:
 
         print("Using kicad-cli for DRC")
         ctx.info("Using KiCad CLI for DRC check...")
-        # logging.info(f"[DRC] Calling run_drc_via_cli for {pcb_file}") # <-- Remove log
         drc_results = await run_drc_via_cli(pcb_file, ctx)
-        # logging.info(f"[DRC] run_drc_via_cli finished for {pcb_file}") # <-- Remove log
 
         # Process and save results if successful
         if drc_results and drc_results.get("success", False):
-            # logging.info(f"[DRC] DRC check successful for {pcb_file}. Saving results.") # <-- Remove log
             # Save results to history
             save_drc_result(project_path, drc_results)
 
@@ -126,12 +121,8 @@ def register_drc_tools(mcp: FastMCP) -> None:
                 else:
                     ctx.info("No change in the number of DRC violations since the last check.")
         elif drc_results:
-            # logging.warning(f"[DRC] DRC check reported failure for {pcb_file}: {drc_results.get('error')}") # <-- Remove log
-            # Pass or print a warning if needed
             pass
         else:
-            # logging.error(f"[DRC] DRC check returned None for {pcb_file}") # <-- Remove log
-            # Pass or print an error if needed
             pass
 
         # Complete progress

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

- **Closes #59**: Remove all commented-out dead code from `kicad_mcp/tools/drc_tools.py` — the `# import logging` line and four commented-out `logging.info/warning/error` calls with `# <-- Remove log` annotations. Orphaned comment-only `elif`/`else` branches are reduced to bare `pass` (the correct minimal body for an empty branch).
- **Closes #60**: Delete the `export_bom_with_python()` stub from `kicad_mcp/tools/bom_tools.py` — it unconditionally returned `{"success": False, "error": "BOM export using Python modules is not fully implemented yet"}`. The `kicad_modules_available` branch in `export_bom_csv()` that invoked the stub is also removed; `export_bom_with_cli` is now called directly as the sole export path.

## Test plan

- [x] `uv run ruff check` — no lint errors
- [x] `uv run pytest tests/ -q --no-cov` — 394 passed, 2 skipped
- [x] `uv run pytest tests/ --cov=kicad_mcp --cov-fail-under=37` — coverage threshold met
- [x] All pre-commit hooks passed (ruff check, ruff format, bandit, TruffleHog, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)