### PR TITLE
fix(text-to-schematic): handle list-of-lists YAML connections and tolerant simple parser

### DIFF
--- a/kicad_mcp/tools/text_to_schematic.py
+++ b/kicad_mcp/tools/text_to_schematic.py
@@ -79,20 +79,35 @@ class TextToSchematicParser:
         self.circuits = []
 
     def parse_yaml_circuit(self, yaml_text: str) -> Circuit:
-        """Parse a YAML-format circuit description."""
+        """Parse a YAML-format circuit description.
+
+        Accepts two top-level shapes:
+        1. Circuit-wrapped: ``circuit "name": { components: [...], ... }``
+        2. Flat: ``{ components: [...], connections: [...], power: [...] }``
+        """
         try:
             data = yaml.safe_load(yaml_text)
+            if not isinstance(data, dict):
+                raise ValueError("YAML root must be a mapping")
 
-            # Extract circuit name
-            circuit_key = list(data.keys())[0]  # First key is circuit name
-            # Remove surrounding quotes if present
-            if circuit_key.startswith('circuit "') and circuit_key.endswith('"'):
-                circuit_name = circuit_key[9:-1]  # Remove 'circuit "' and closing '"'
-            elif circuit_key.startswith("circuit "):
-                circuit_name = circuit_key[8:]  # Remove 'circuit '
+            section_keys = {"components", "power", "connections"}
+            if section_keys & set(data.keys()):
+                circuit_name = "Untitled Circuit"
+                circuit_data = data
             else:
-                circuit_name = circuit_key
-            circuit_data = data[circuit_key]
+                circuit_key = list(data.keys())[0]  # First key is circuit name
+                if circuit_key.startswith('circuit "') and circuit_key.endswith('"'):
+                    circuit_name = circuit_key[9:-1]  # Remove 'circuit "' and closing '"'
+                elif circuit_key.startswith("circuit "):
+                    circuit_name = circuit_key[8:]  # Remove 'circuit '
+                else:
+                    circuit_name = circuit_key
+                circuit_data = data[circuit_key]
+                if not isinstance(circuit_data, dict):
+                    raise ValueError(
+                        f"circuit body for '{circuit_key}' must be a mapping, "
+                        f"got {type(circuit_data).__name__}"
+                    )
 
             # Parse components
             components = []
@@ -122,12 +137,18 @@ class TextToSchematicParser:
             if "power" in circuit_data:
                 for power_item in circuit_data["power"]:
                     if isinstance(power_item, dict):
-                        # YAML parses "VCC: +5V..." as {"VCC": "+5V..."}
-                        for ref, desc in power_item.items():
-                            power_desc = f"{ref}: {desc}"
-                            power_symbol = self._parse_power_symbol(power_desc)
+                        if "net" in power_item or "type" in power_item:
+                            # Structured: {net: "3V3", type: "VCC", position: [x, y]}
+                            power_symbol = self._parse_structured_power(power_item)
                             if power_symbol:
                                 power_symbols.append(power_symbol)
+                        else:
+                            # YAML parses "VCC: +5V..." as {"VCC": "+5V..."}
+                            for ref, desc in power_item.items():
+                                power_desc = f"{ref}: {desc}"
+                                power_symbol = self._parse_power_symbol(power_desc)
+                                if power_symbol:
+                                    power_symbols.append(power_symbol)
                     else:
                         # String format
                         power_symbol = self._parse_power_symbol(power_item)
@@ -153,7 +174,10 @@ class TextToSchematicParser:
             raise ValueError(f"Error parsing YAML circuit: {str(e)}") from e
 
     def parse_simple_text(self, text: str) -> Circuit:
-        """Parse a simple text format circuit description."""
+        """Parse a simple text format circuit description.
+
+        Tolerates optional ``- `` YAML-style bullet prefixes on entries.
+        """
         lines = text.strip().split("\n")
         circuit_name = "Untitled Circuit"
         components = []
@@ -162,14 +186,28 @@ class TextToSchematicParser:
 
         current_section = None
 
-        for line in lines:
-            line = line.strip()
+        for raw_line in lines:
+            line = raw_line.strip()
             if not line or line.startswith("#"):
                 continue
 
+            # Strip YAML-style bullet prefix so "- R1: resistor ..." parses
+            # the same as "R1: resistor ..."
+            if line.startswith("- "):
+                line = line[2:].lstrip()
+
             # Check for circuit name
             if line.startswith("circuit"):
-                circuit_name = line.split(":", 1)[1].strip().strip("\"'")
+                parts = line.split(":", 1)
+                if len(parts) == 2:
+                    # Extract from 'circuit "name":' — prefer quoted form
+                    header = parts[0]
+                    if '"' in header:
+                        circuit_name = header.split('"', 1)[1].rsplit('"', 1)[0]
+                    elif header.strip() == "circuit":
+                        circuit_name = parts[1].strip().strip("\"'") or circuit_name
+                    else:
+                        circuit_name = header[len("circuit") :].strip().strip("\"'")
                 continue
 
             # Check for section headers
@@ -284,8 +322,16 @@ class TextToSchematicParser:
             return None
 
     def _parse_component_simple(self, line: str) -> Component | None:
-        """Parse a component from simple text format."""
-        # Format: "R1 resistor 220Ω (10, 20)"
+        """Parse a component from simple text format.
+
+        Two accepted shapes:
+        - ``R1 resistor 220 (10, 20)`` — whitespace-separated
+        - ``R1: resistor 220 at (10, 20)`` — YAML-ish (delegates to _parse_component)
+        """
+        # YAML-ish shape: "R1: resistor 220 at (10, 20)"
+        if ":" in line and " at " in line:
+            return self._parse_component(line)
+
         try:
             parts = line.split()
             if len(parts) < 3:
@@ -348,9 +394,29 @@ class TextToSchematicParser:
         except Exception:
             return None
 
+    def _parse_structured_power(self, power_data: dict) -> PowerSymbol | None:
+        """Parse a power symbol from structured YAML: ``{net, type, position}``."""
+        try:
+            net = power_data.get("net", "")
+            power_type = power_data.get("type", net)
+            position_data = power_data.get("position", [0, 0])
+            if not net:
+                return None
+            if isinstance(position_data, list | tuple) and len(position_data) >= 2:
+                position = (float(position_data[0]), float(position_data[1]))
+            else:
+                position = (0.0, 0.0)
+            return PowerSymbol(reference=net, power_type=power_type, position=position)
+        except Exception:
+            return None
+
     def _parse_power_symbol_simple(self, line: str) -> PowerSymbol | None:
-        """Parse a power symbol from simple text format."""
-        # Format: "VCC +5V (10, 10)"
+        """Parse a power symbol from simple text format.
+
+        Accepts ``VCC +5V (10, 10)`` and ``VCC: +5V at (10, 10)``.
+        """
+        if ":" in line and " at " in line:
+            return self._parse_power_symbol(line)
         try:
             parts = line.split()
             if len(parts) < 2:
@@ -380,32 +446,37 @@ class TextToSchematicParser:
         except Exception:
             return None
 
-    def _parse_connection(self, conn_desc: str) -> Connection | None:
-        """Parse a connection description from YAML format."""
-        # Format: "VCC → R1.1" or "R1.2 → LED1.anode"
+    def _parse_connection(self, conn_desc: Any) -> Connection | None:
+        """Parse a connection description.
+
+        Accepts:
+        - Strings: "VCC -> R1.1", "R1.2 → LED1.anode", "R1.2 — GND"
+        - Two-element list/tuple: ["U1:GPIO2", "R1:1"] (YAML list-of-lists form)
+
+        Pin separator may be ``.`` or ``:``.
+        """
         try:
-            # Handle different arrow formats
-            if "→" in conn_desc:
-                start, end = conn_desc.split("→", 1)
-            elif "->" in conn_desc:
-                start, end = conn_desc.split("->", 1)
-            elif "—" in conn_desc:
-                start, end = conn_desc.split("—", 1)
+            if isinstance(conn_desc, list | tuple):
+                if len(conn_desc) != 2:
+                    return None
+                start, end = str(conn_desc[0]), str(conn_desc[1])
+            elif isinstance(conn_desc, str):
+                if "→" in conn_desc:
+                    start, end = conn_desc.split("→", 1)
+                elif "->" in conn_desc:
+                    start, end = conn_desc.split("->", 1)
+                elif "—" in conn_desc:
+                    start, end = conn_desc.split("—", 1)
+                else:
+                    return None
             else:
                 return None
 
             start = start.strip()
             end = end.strip()
 
-            # Parse start component and pin
-            start_parts = start.split(".")
-            start_component = start_parts[0]
-            start_pin = start_parts[1] if len(start_parts) > 1 else None
-
-            # Parse end component and pin
-            end_parts = end.split(".")
-            end_component = end_parts[0]
-            end_pin = end_parts[1] if len(end_parts) > 1 else None
+            start_component, start_pin = self._split_endpoint(start)
+            end_component, end_pin = self._split_endpoint(end)
 
             return Connection(
                 start_component=start_component,
@@ -416,6 +487,15 @@ class TextToSchematicParser:
 
         except Exception:
             return None
+
+    @staticmethod
+    def _split_endpoint(endpoint: str) -> tuple[str, str | None]:
+        """Split ``U1.GPIO2`` or ``U1:GPIO2`` into (component, pin)."""
+        for sep in (".", ":"):
+            if sep in endpoint:
+                component, pin = endpoint.split(sep, 1)
+                return component.strip(), pin.strip() or None
+        return endpoint, None
 
     def _parse_connection_simple(self, line: str) -> Connection | None:
         """Parse a connection from simple text format."""

--- a/tests/unit/tools/test_text_to_schematic_parsers.py
+++ b/tests/unit/tools/test_text_to_schematic_parsers.py
@@ -1,0 +1,135 @@
+"""Regression tests for text_to_schematic parser bugs (#19, #20)."""
+
+from kicad_mcp.tools.text_to_schematic import TextToSchematicParser
+
+
+class TestSimpleFormatParser:
+    """Issue #20: 'simple' format docs use ``- R1: type value at (x, y)``."""
+
+    def test_yaml_bullet_prefix_is_stripped(self):
+        """Lines starting with ``- `` are parsed the same as bare lines."""
+        parser = TextToSchematicParser()
+        text = """circuit "demo":
+  components:
+    - R1: resistor 330 at (10, 20)
+  power:
+    - VCC: 3.3V at (5, 5)
+  connections:
+    - R1.1 -> VCC"""
+        circuit = parser.parse_simple_text(text)
+
+        assert circuit.name == "demo"
+        assert len(circuit.components) == 1
+        comp = circuit.components[0]
+        assert comp.reference == "R1"
+        assert comp.component_type == "resistor"
+        assert comp.value == "330"
+        assert comp.position == (10.0, 20.0)
+
+        assert len(circuit.power_symbols) == 1
+        assert circuit.power_symbols[0].reference == "VCC"
+        assert circuit.power_symbols[0].power_type == "3.3V"
+
+        assert len(circuit.connections) == 1
+        conn = circuit.connections[0]
+        assert conn.start_component == "R1"
+        assert conn.start_pin == "1"
+        assert conn.end_component == "VCC"
+
+    def test_full_issue_20_input_parses(self):
+        """Exact input from issue #20 must parse without raising."""
+        parser = TextToSchematicParser()
+        text = """circuit "ESP32 with LED and Button":
+  components:
+    - U1: ic ESP32-DevKitC at (100, 100)
+    - R1: resistor 330 at (160, 80)
+    - D1: led LED at (160, 120)
+    - SW1: switch SW_Push at (40, 80)
+    - R2: resistor 10k at (40, 120)
+  power:
+    - VCC: 3.3V at (40, 150)
+    - GND: GND at (160, 150)
+  connections:
+    - U1.GPIO2 -> R1.1
+    - R1.2 -> D1.A
+    - D1.K -> GND
+    - U1.GPIO4 -> SW1.1
+    - SW1.2 -> R2.1
+    - R2.2 -> VCC
+    - U1.GND -> GND
+    - U1.3V3 -> VCC"""
+        circuit = parser.parse_simple_text(text)
+
+        assert circuit.name == "ESP32 with LED and Button"
+        assert len(circuit.components) == 5
+        assert {c.reference for c in circuit.components} == {"U1", "R1", "D1", "SW1", "R2"}
+        assert len(circuit.power_symbols) == 2
+        assert len(circuit.connections) == 8
+
+
+class TestYamlFormatParser:
+    """Issue #19: flat YAML with list-of-lists connections."""
+
+    def test_flat_yaml_without_circuit_wrapper(self):
+        """Top-level components/power/connections keys are accepted."""
+        parser = TextToSchematicParser()
+        text = """components:
+  - reference: U1
+    type: ic
+    value: ESP32-DevKitC
+    position: [100, 100]
+connections:
+  - - U1:GPIO2
+    - R1:1
+power:
+  - net: 3V3
+    type: VCC
+    position: [50, 150]"""
+        circuit = parser.parse_yaml_circuit(text)
+
+        assert len(circuit.components) == 1
+        comp = circuit.components[0]
+        assert comp.reference == "U1"
+        assert comp.component_type == "ic"
+        assert comp.position == (100.0, 100.0)
+
+        assert len(circuit.power_symbols) == 1
+        assert circuit.power_symbols[0].reference == "3V3"
+        assert circuit.power_symbols[0].power_type == "VCC"
+
+        assert len(circuit.connections) == 1
+        conn = circuit.connections[0]
+        assert conn.start_component == "U1"
+        assert conn.start_pin == "GPIO2"
+        assert conn.end_component == "R1"
+        assert conn.end_pin == "1"
+
+    def test_list_of_lists_connections(self):
+        """``[[a, b], [c, d]]`` connection format from issue #19."""
+        parser = TextToSchematicParser()
+        text = """components:
+  - reference: A
+    type: resistor
+    value: "1k"
+    position: [0, 0]
+connections:
+  - - A:1
+    - B:2
+  - - B:3
+    - C:4"""
+        circuit = parser.parse_yaml_circuit(text)
+
+        assert len(circuit.connections) == 2
+        assert circuit.connections[0].start_component == "A"
+        assert circuit.connections[0].end_component == "B"
+        assert circuit.connections[1].start_component == "B"
+        assert circuit.connections[1].end_component == "C"
+
+    def test_colon_pin_separator(self):
+        """``U1:GPIO2`` (YAML-friendly) parses same as ``U1.GPIO2``."""
+        parser = TextToSchematicParser()
+        dot = parser._parse_connection("U1.GPIO2 -> R1.1")
+        colon = parser._parse_connection("U1:GPIO2 -> R1:1")
+        assert dot is not None and colon is not None
+        assert (dot.start_component, dot.start_pin) == (colon.start_component, colon.start_pin)
+        assert (dot.end_component, dot.end_pin) == (colon.end_component, colon.end_pin)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

- Closes #19 — accept **flat YAML** (top-level `components`/`power`/`connections`) in addition to the `circuit "name":` wrapper; connection entries may be **list-of-lists** (`[[a, b], [c, d]]`); pin separator may be `.` or `:`; structured power symbols (`{net, type, position}`) are recognized.
- Closes #20 — simple-format lines may carry a YAML-style `- ` bullet prefix; `_parse_component_simple` delegates to `_parse_component` when the line uses `R1: type value at (x, y)` shape (previously the bullet was consumed as the reference).

## Root causes

- `parse_yaml_circuit` assumed the YAML root was always `{circuit "name": {...}}` and blindly took `list(data.keys())[0]` as the name. Issue #19's input has top-level `components:` / `connections:` / `power:`, so `circuit_data` became a list and all subsequent `"components" in circuit_data` checks silently failed. Connections as lists (`- - a` / `  - b`) also hit `_parse_connection` which `split` on a string — no crash in the current code path but no parse either.
- `_parse_component_simple` split on whitespace: `- U1: ic ESP32-DevKitC at (100, 100)` → `parts[0] = "-"`, `parts[1] = "U1:"`, so the component was created with `reference="-"`. `parse_simple_text` also didn't extract the name correctly from `circuit "ESP32 …":`.

## Test plan

- New `tests/unit/tools/test_text_to_schematic_parsers.py` exercises both issues' exact documented inputs.
- Full suite: `399 passed, 2 skipped` (skips are #2-related, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)