### PR TITLE
ci: add pip-audit dependency scan to security job (closes #42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,12 @@ jobs:
     - name: Install dependencies
       run: uv sync --group dev
 
-    - name: Run security scan
+    - name: Run security scan with bandit
       run: uv run bandit -c pyproject.toml -r kicad_mcp/
+
+    - name: Scan dependencies with pip-audit
+      continue-on-error: true
+      run: uv run --with pip-audit pip-audit
 
   build:
     runs-on: ubuntu-latest

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

Closes #42. Adds a dependency-vulnerability scan to the \`security\` job in \`.github/workflows/ci.yml\`.

## Choice of scanner

Issue #42 suggested \`safety\`. \`safety check\` is deprecated and its current PyPI release (3.2.9) crashes with \`post_dump() got an unexpected keyword argument 'pass_many'\` on modern marshmallow. \`safety scan\` (the non-deprecated replacement) requires an API key / account. Given the choice, I went with \`pip-audit\` (PyPA-maintained, no auth):

\`\`\`yaml
- name: Scan dependencies with pip-audit
  continue-on-error: true
  run: uv run --with pip-audit pip-audit
\`\`\`

\`continue-on-error: true\` keeps advisories informational — they don't block CI but show up as annotations.

## Test plan

- Verified locally: \`uv run --with pip-audit pip-audit\` runs and reports findings against the current lockfile.
- Workflow syntax validated by the pre-commit actionlint hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)