### PR TITLE
refactor: migrate print() to logging in BOM/export/netlist modules

### DIFF
--- a/kicad_mcp/resources/bom_resources.py
+++ b/kicad_mcp/resources/bom_resources.py
@@ -3,6 +3,7 @@ Bill of Materials (BOM) resources for KiCad projects.
 """
 
 import json
+import logging
 import os
 
 from fastmcp import FastMCP
@@ -11,6 +12,8 @@ import pandas as pd
 # Import the helper functions from bom_tools.py to avoid code duplication
 from kicad_mcp.tools.bom_tools import analyze_bom_data, parse_bom_file
 from kicad_mcp.utils.file_utils import get_project_files
+
+logger = logging.getLogger(__name__)
 
 
 def register_bom_resources(mcp: FastMCP) -> None:
@@ -30,7 +33,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted BOM report
         """
-        print(f"Generating BOM report for project: {project_path}")
+        logger.info("Generating BOM report for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -43,10 +46,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return f"# BOM Report\n\nNo BOM files found for project: {os.path.basename(project_path)}.\n\nExport a BOM from KiCad first, or use the `export_bom_csv` tool to generate one."
 
         # Format as Markdown report
@@ -159,7 +162,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
                 report += "\n---\n\n"
 
             except Exception as e:
-                print(f"Error processing BOM file {file_path}: {str(e)}")
+                logger.error("Error processing BOM file %s: %s", file_path, e)
                 report += f"## {file_type}\n\nError processing BOM file: {str(e)}\n\n"
 
         # Add export instructions
@@ -183,7 +186,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             CSV-formatted BOM data
         """
-        print(f"Generating CSV BOM for project: {project_path}")
+        logger.info("Generating CSV BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -196,10 +199,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return "No BOM files found for project. Export a BOM from KiCad first."
 
         # Use the first BOM file found
@@ -223,7 +226,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
             return df.to_csv(index=False)
 
         except Exception as e:
-            print(f"Error generating CSV from BOM file: {str(e)}")
+            logger.error("Error generating CSV from BOM file: %s", e)
             return f"Error generating CSV from BOM file: {str(e)}"
 
     @mcp.resource("kicad://bom/{project_path}/json")
@@ -236,7 +239,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             JSON-formatted BOM data
         """
-        print(f"Generating JSON BOM for project: {project_path}")
+        logger.info("Generating JSON BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -249,10 +252,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith((".csv", ".json")):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return json.dumps({"error": "No BOM files found for project"}, indent=2)
 
         try:
@@ -285,5 +288,5 @@ def register_bom_resources(mcp: FastMCP) -> None:
             return json.dumps(result, indent=2, default=str)
 
         except Exception as e:
-            print(f"Error generating JSON from BOM file: {str(e)}")
+            logger.error("Error generating JSON from BOM file: %s", e)
             return json.dumps({"error": str(e)}, indent=2)

--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -4,6 +4,7 @@ Bill of Materials (BOM) processing tools for KiCad projects.
 
 import csv
 import json
+import logging
 import os
 from typing import Any
 
@@ -11,6 +12,8 @@ from fastmcp import Context, FastMCP
 import pandas as pd
 
 from kicad_mcp.utils.file_utils import get_project_files
+
+logger = logging.getLogger(__name__)
 
 
 def register_bom_tools(mcp: FastMCP) -> None:
@@ -34,10 +37,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with BOM analysis results
         """
-        print(f"Analyzing BOM for project: {project_path}")
+        logger.info("Analyzing BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
@@ -53,10 +56,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             await ctx.info("No BOM files found for project")
             return {
                 "success": False,
@@ -85,7 +88,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 bom_data, format_info = parse_bom_file(file_path)
 
                 if not bom_data or len(bom_data) == 0:
-                    print(f"Failed to parse BOM file: {file_path}")
+                    logger.warning("Failed to parse BOM file: %s", file_path)
                     continue
 
                 # Analyze the BOM data
@@ -102,10 +105,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 total_unique_components += analysis["unique_component_count"]
                 total_components += analysis["total_component_count"]
 
-                print(f"Successfully analyzed BOM file: {file_path}")
+                logger.info("Successfully analyzed BOM file: %s", file_path)
 
             except Exception as e:
-                print(f"Error analyzing BOM file {file_path}: {str(e)}", exc_info=True)
+                logger.error("Error analyzing BOM file %s: %s", file_path, e, exc_info=True)
                 results["bom_files"][file_type] = {"path": file_path, "error": str(e)}
 
         await ctx.report_progress(70, 100)
@@ -171,10 +174,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with export results
         """
-        print(f"Exporting BOM for project: {project_path}")
+        logger.info("Exporting BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
@@ -190,7 +193,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
         # We need the schematic file to generate a BOM
         if "schematic" not in files:
-            print("Schematic file not found in project")
+            logger.warning("Schematic file not found in project")
             await ctx.info("Schematic file not found in project")
             return {"success": False, "error": "Schematic file not found"}
 
@@ -213,7 +216,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                     schematic_file, project_dir, project_name, ctx
                 )
             except Exception as e:
-                print(f"Error exporting BOM with Python modules: {str(e)}", exc_info=True)
+                logger.error("Error exporting BOM with Python modules: %s", e, exc_info=True)
                 await ctx.info(f"Error using Python modules: {str(e)}")
                 export_result = {"success": False, "error": str(e)}
 
@@ -225,7 +228,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                     schematic_file, project_dir, project_name, ctx
                 )
             except Exception as e:
-                print(f"Error exporting BOM with CLI: {str(e)}", exc_info=True)
+                logger.error("Error exporting BOM with CLI: %s", e, exc_info=True)
                 await ctx.info(f"Error using command-line tools: {str(e)}")
                 export_result = {"success": False, "error": str(e)}
 
@@ -255,7 +258,7 @@ def parse_bom_file(file_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]
             - List of component dictionaries
             - Dictionary with format information
     """
-    print(f"Parsing BOM file: {file_path}")
+    logger.info("Parsing BOM file: %s", file_path)
 
     # Check file extension
     _, ext = os.path.splitext(file_path)
@@ -352,18 +355,18 @@ def parse_bom_file(file_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]
                     for row in reader:
                         components.append(dict(row))
             except Exception:
-                print(f"Failed to parse unknown file format: {file_path}")
+                logger.warning("Failed to parse unknown file format: %s", file_path)
                 return [], {"detected_format": "unsupported"}
 
     except Exception as e:
-        print(f"Error parsing BOM file: {str(e)}", exc_info=True)
+        logger.error("Error parsing BOM file: %s", e, exc_info=True)
         return [], {"error": str(e)}
 
     # Check if we actually got components
     if not components:
-        print(f"No components found in BOM file: {file_path}")
+        logger.warning("No components found in BOM file: %s", file_path)
     else:
-        print(f"Successfully parsed {len(components)} components from {file_path}")
+        logger.info("Successfully parsed %d components from %s", len(components), file_path)
 
         # Add a sample of the fields found
         if components:
@@ -384,7 +387,7 @@ def analyze_bom_data(
     Returns:
         Dictionary with analysis results
     """
-    print(f"Analyzing {len(components)} components")
+    logger.debug("Analyzing %d components", len(components))
 
     # Initialize results
     results = {
@@ -567,7 +570,7 @@ def analyze_bom_data(
                     if "currency" not in results:
                         results["currency"] = "USD"  # Default
             except Exception:
-                print("Failed to parse cost data")
+                logger.warning("Failed to parse cost data")
 
         # Add extra insights
         if ref_col and value_col:
@@ -577,7 +580,7 @@ def analyze_bom_data(
             results["most_common_values"] = {str(k): int(v) for k, v in most_common.items()}
 
     except Exception as e:
-        print(f"Error analyzing BOM data: {str(e)}", exc_info=True)
+        logger.error("Error analyzing BOM data: %s", e, exc_info=True)
         # Fallback to basic analysis
         results["unique_component_count"] = len(components)
         results["total_component_count"] = len(components)
@@ -599,7 +602,7 @@ async def export_bom_with_python(
     Returns:
         Dictionary with export results
     """
-    print(f"Exporting BOM for schematic: {schematic_file}")
+    logger.info("Exporting BOM for schematic: %s", schematic_file)
     await ctx.report_progress(30, 100)
 
     try:
@@ -608,7 +611,7 @@ async def export_bom_with_python(
         # is complex and KiCad's API for this is not well-documented
 
         # For now, return a message indicating this method is not implemented yet
-        print("BOM export with Python modules not fully implemented")
+        logger.info("BOM export with Python modules not fully implemented")
         await ctx.info("BOM export with Python modules not fully implemented yet")
 
         return {
@@ -618,7 +621,7 @@ async def export_bom_with_python(
         }
 
     except ImportError:
-        print("Failed to import KiCad Python modules")
+        logger.warning("Failed to import KiCad Python modules")
         return {
             "success": False,
             "error": "Failed to import KiCad Python modules",
@@ -643,7 +646,7 @@ async def export_bom_with_cli(
     from kicad_mcp.utils.kicad_cli import KiCadCLIError
     from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
-    print("Exporting BOM using CLI tools via SecureSubprocessRunner")
+    logger.info("Exporting BOM using CLI tools via SecureSubprocessRunner")
     await ctx.report_progress(40, 100)
 
     # Output file path
@@ -653,7 +656,7 @@ async def export_bom_with_cli(
     command_args = ["sch", "export", "bom", "--output", output_file, schematic_file]
 
     try:
-        print("Running BOM export command via SecureSubprocessRunner")
+        logger.info("Running BOM export command via SecureSubprocessRunner")
         await ctx.report_progress(60, 100)
 
         runner = get_subprocess_runner()
@@ -665,8 +668,8 @@ async def export_bom_with_cli(
 
         # Check if the command was successful
         if process.returncode != 0:
-            print(f"BOM export command failed with code {process.returncode}")
-            print(f"Error output: {process.stderr}")
+            logger.error("BOM export command failed with code %d", process.returncode)
+            logger.error("Error output: %s", process.stderr)
 
             return {
                 "success": False,
@@ -706,7 +709,7 @@ async def export_bom_with_cli(
         }
 
     except (SecureSubprocessError, KiCadCLIError) as e:
-        print(f"BOM export command failed: {e}")
+        logger.error("BOM export command failed: %s", e)
         return {
             "success": False,
             "error": f"BOM export command failed: {e}",
@@ -714,7 +717,7 @@ async def export_bom_with_cli(
         }
 
     except Exception as e:
-        print(f"Error exporting BOM: {str(e)}", exc_info=True)
+        logger.error("Error exporting BOM: %s", e, exc_info=True)
         return {
             "success": False,
             "error": f"Error exporting BOM: {str(e)}",

--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -258,7 +258,7 @@ def parse_bom_file(file_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]
             - List of component dictionaries
             - Dictionary with format information
     """
-    logger.info("Parsing BOM file: %s", file_path)
+    logger.debug("Parsing BOM file: %s", file_path)
 
     # Check file extension
     _, ext = os.path.splitext(file_path)
@@ -366,7 +366,7 @@ def parse_bom_file(file_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]
     if not components:
         logger.warning("No components found in BOM file: %s", file_path)
     else:
-        logger.info("Successfully parsed %d components from %s", len(components), file_path)
+        logger.debug("Successfully parsed %d components from %s", len(components), file_path)
 
         # Add a sample of the fields found
         if components:

--- a/kicad_mcp/tools/export_tools.py
+++ b/kicad_mcp/tools/export_tools.py
@@ -3,6 +3,7 @@ Export tools for KiCad projects.
 """
 
 import asyncio
+import logging
 import os
 
 from fastmcp import Context, FastMCP
@@ -16,6 +17,8 @@ from kicad_mcp.utils.path_validator import (
     validate_kicad_file,
 )
 from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, SecureSubprocessRunner
+
+logger = logging.getLogger(__name__)
 
 
 def register_export_tools(mcp: FastMCP) -> None:
@@ -41,7 +44,7 @@ def register_export_tools(mcp: FastMCP) -> None:
             app_context = ctx.request_context.lifespan_context
             # Removed check for kicad_modules_available as we now use CLI
 
-            print(f"Generating thumbnail via CLI for project: {project_path}")
+            logger.info("Generating thumbnail via CLI for project: %s", project_path)
 
             # Validate and sanitize project path
             try:
@@ -49,24 +52,24 @@ def register_export_tools(mcp: FastMCP) -> None:
                     project_path, "project", must_exist=True
                 )
             except PathValidationError as e:
-                print(f"Invalid project path: {e}")
+                logger.warning("Invalid project path: %s", e)
                 await ctx.info(f"Invalid project path: {e}")
                 return None
 
             # Get PCB file from project
             files = get_project_files(validated_project_path)
             if "pcb" not in files:
-                print("PCB file not found in project")
+                logger.warning("PCB file not found in project")
                 await ctx.info("PCB file not found in project")
                 return None
 
             pcb_file = files["pcb"]
-            print(f"Found PCB file: {pcb_file}")
+            logger.debug("Found PCB file: %s", pcb_file)
 
             # Check cache
             cache_key = f"thumbnail_cli_{pcb_file}_{os.path.getmtime(pcb_file)}"
             if hasattr(app_context, "cache") and cache_key in app_context.cache:
-                print(f"Using cached CLI thumbnail for {pcb_file}")
+                logger.debug("Using cached CLI thumbnail for %s", pcb_file)
                 return app_context.cache[cache_key]
 
             await ctx.report_progress(PROGRESS_CONSTANTS["start"], PROGRESS_CONSTANTS["complete"])
@@ -79,22 +82,22 @@ def register_export_tools(mcp: FastMCP) -> None:
                     # Cache the result if possible
                     if hasattr(app_context, "cache"):
                         app_context.cache[cache_key] = thumbnail
-                    print("Thumbnail generated successfully via CLI.")
+                    logger.info("Thumbnail generated successfully via CLI.")
                     return thumbnail
                 else:
-                    print("generate_thumbnail_with_cli returned None")
+                    logger.warning("generate_thumbnail_with_cli returned None")
                     await ctx.info("Failed to generate thumbnail using kicad-cli.")
                     return None
             except Exception as e:
-                print(f"Error calling generate_thumbnail_with_cli: {str(e)}", exc_info=True)
+                logger.error("Error calling generate_thumbnail_with_cli: %s", e, exc_info=True)
                 await ctx.info(f"Error generating thumbnail with kicad-cli: {str(e)}")
                 return None
 
         except asyncio.CancelledError:
-            print("Thumbnail generation cancelled")
+            logger.info("Thumbnail generation cancelled")
             raise  # Re-raise to let MCP know the task was cancelled
         except Exception as e:
-            print(f"Unexpected error in thumbnail generation: {str(e)}")
+            logger.error("Unexpected error in thumbnail generation: %s", e)
             await ctx.info(f"Error: {str(e)}")
             return None
 
@@ -102,8 +105,9 @@ def register_export_tools(mcp: FastMCP) -> None:
     async def generate_project_thumbnail(project_path: str, ctx: Context):
         """Generate a thumbnail of a KiCad project's PCB layout (Alias for generate_pcb_thumbnail)."""
         # This function now just calls the main CLI-based thumbnail generator
-        print(
-            f"generate_project_thumbnail called, redirecting to generate_pcb_thumbnail for {project_path}"
+        logger.info(
+            "generate_project_thumbnail called, redirecting to generate_pcb_thumbnail for %s",
+            project_path,
         )
         return await generate_pcb_thumbnail(project_path, ctx)
 
@@ -121,14 +125,14 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
         Image object containing the PCB thumbnail or None if generation failed
     """
     try:
-        print("Attempting to generate thumbnail using KiCad CLI tools")
+        logger.info("Attempting to generate thumbnail using KiCad CLI tools")
         await ctx.report_progress(PROGRESS_CONSTANTS["detection"], PROGRESS_CONSTANTS["complete"])
 
         # Validate and sanitize PCB file path
         try:
             validated_pcb_file = validate_kicad_file(pcb_file, "pcb", must_exist=True)
         except PathValidationError as e:
-            print(f"Invalid PCB file path: {e}")
+            logger.warning("Invalid PCB file path: %s", e)
             await ctx.info(f"Invalid PCB file path: {e}")
             return None
 
@@ -137,7 +141,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
         try:
             validated_project_dir = validate_directory(project_dir, must_exist=True)
         except PathValidationError as e:
-            print(f"Invalid project directory: {e}")
+            logger.warning("Invalid project directory: %s", e)
             await ctx.info(f"Invalid project directory: {e}")
             return None
 
@@ -163,7 +167,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
             validated_pcb_file,
         ]
 
-        print(f"Running KiCad CLI command: {' '.join(command_args)}")
+        logger.debug("Running KiCad CLI command: %s", " ".join(command_args))
         await ctx.report_progress(PROGRESS_CONSTANTS["processing"], PROGRESS_CONSTANTS["complete"])
 
         # Run the command using secure subprocess runner
@@ -177,27 +181,27 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
             )
 
             if process.returncode != 0:
-                print(f"Command failed with code {process.returncode}")
-                print(f"Stderr: {process.stderr}")
-                print(f"Stdout: {process.stdout}")
+                logger.error("Command failed with code %d", process.returncode)
+                logger.error("Stderr: %s", process.stderr)
+                logger.error("Stdout: %s", process.stdout)
                 await ctx.info(f"KiCad CLI command failed: {process.stderr or process.stdout}")
                 return None
 
-            print(f"Command successful: {process.stdout}")
+            logger.debug("Command successful: %s", process.stdout)
             await ctx.report_progress(
                 PROGRESS_CONSTANTS["finishing"], PROGRESS_CONSTANTS["complete"]
             )
 
             # Check if the output file was created
             if not os.path.exists(output_file):
-                print(f"Output file not created: {output_file}")
+                logger.error("Output file not created: %s", output_file)
                 return None
 
             # Read the image file
             with open(output_file, "rb") as f:
                 img_data = f.read()
 
-            print(f"Successfully generated thumbnail with CLI, size: {len(img_data)} bytes")
+            logger.info("Successfully generated thumbnail with CLI, size: %d bytes", len(img_data))
             await ctx.report_progress(
                 PROGRESS_CONSTANTS["validation"], PROGRESS_CONSTANTS["complete"]
             )
@@ -206,18 +210,18 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
             return Image(data=img_data, format="svg")
 
         except SecureSubprocessError as e:
-            print(f"Secure subprocess error: {e}")
+            logger.error("Secure subprocess error: %s", e)
             await ctx.info(f"KiCad CLI command failed: {e}")
             return None
         except Exception as e:
-            print(f"Error running CLI command: {str(e)}", exc_info=True)
+            logger.error("Error running CLI command: %s", e, exc_info=True)
             await ctx.info(f"Error running KiCad CLI: {str(e)}")
             return None
 
     except asyncio.CancelledError:
-        print("CLI thumbnail generation cancelled")
+        logger.info("CLI thumbnail generation cancelled")
         raise
     except Exception as e:
-        print(f"Unexpected error in CLI thumbnail generation: {str(e)}")
+        logger.error("Unexpected error in CLI thumbnail generation: %s", e)
         await ctx.info(f"Unexpected error: {str(e)}")
         return None

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -89,7 +89,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            logger.error("Error extracting netlist: %s", e)
+            logger.error("Error extracting netlist: %s", e, exc_info=True)
             await ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -143,7 +143,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            logger.error("Error extracting project netlist: %s", e)
+            logger.error("Error extracting project netlist: %s", e, exc_info=True)
             await ctx.info(f"Error extracting project netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -253,7 +253,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            logger.error("Error analyzing connections: %s", e)
+            logger.error("Error analyzing connections: %s", e, exc_info=True)
             await ctx.info(f"Error analyzing connections: {str(e)}")
             return {"success": False, "error": str(e)}
 

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -2,6 +2,7 @@
 Netlist extraction and analysis tools for KiCad schematics.
 """
 
+import logging
 import os
 from typing import Any
 
@@ -9,6 +10,8 @@ from fastmcp import Context, FastMCP
 
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.netlist_parser import analyze_netlist, extract_netlist
+
+logger = logging.getLogger(__name__)
 
 
 def register_netlist_tools(mcp: FastMCP) -> None:
@@ -32,10 +35,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with netlist information
         """
-        print(f"Extracting netlist from schematic: {schematic_path}")
+        logger.info("Extracting netlist from schematic: %s", schematic_path)
 
         if not os.path.exists(schematic_path):
-            print(f"Schematic file not found: {schematic_path}")
+            logger.warning("Schematic file not found: %s", schematic_path)
             await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
@@ -51,7 +54,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
-                print(f"Error extracting netlist: {netlist_data['error']}")
+                logger.error("Error extracting netlist: %s", netlist_data["error"])
                 await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
@@ -86,7 +89,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            print(f"Error extracting netlist: {str(e)}")
+            logger.error("Error extracting netlist: %s", e)
             await ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -104,10 +107,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with netlist information
         """
-        print(f"Extracting netlist for project: {project_path}")
+        logger.info("Extracting netlist for project: %s", project_path)
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
@@ -119,12 +122,12 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             files = get_project_files(project_path)
 
             if "schematic" not in files:
-                print("Schematic file not found in project")
+                logger.warning("Schematic file not found in project")
                 await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
-            print(f"Found schematic file: {schematic_path}")
+            logger.info("Found schematic file: %s", schematic_path)
             await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Extract netlist
@@ -140,7 +143,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            print(f"Error extracting project netlist: {str(e)}")
+            logger.error("Error extracting project netlist: %s", e)
             await ctx.info(f"Error extracting project netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -158,10 +161,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with connection analysis
         """
-        print(f"Analyzing connections in schematic: {schematic_path}")
+        logger.info("Analyzing connections in schematic: %s", schematic_path)
 
         if not os.path.exists(schematic_path):
-            print(f"Schematic file not found: {schematic_path}")
+            logger.warning("Schematic file not found: %s", schematic_path)
             await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
@@ -174,7 +177,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
-                print(f"Error extracting netlist: {netlist_data['error']}")
+                logger.error("Error extracting netlist: %s", netlist_data["error"])
                 await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
@@ -250,7 +253,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            print(f"Error analyzing connections: {str(e)}")
+            logger.error("Error analyzing connections: %s", e)
             await ctx.info(f"Error analyzing connections: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -271,10 +274,12 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with component connection information
         """
-        print(f"Finding connections for component {component_ref} in project: {project_path}")
+        logger.info(
+            "Finding connections for component %s in project: %s", component_ref, project_path
+        )
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
@@ -286,12 +291,12 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             files = get_project_files(project_path)
 
             if "schematic" not in files:
-                print("Schematic file not found in project")
+                logger.warning("Schematic file not found in project")
                 await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
-            print(f"Found schematic file: {schematic_path}")
+            logger.info("Found schematic file: %s", schematic_path)
             await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Extract netlist
@@ -301,14 +306,14 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
-                print(f"Failed to extract netlist: {netlist_data['error']}")
+                logger.error("Failed to extract netlist: %s", netlist_data["error"])
                 await ctx.info(f"Failed to extract netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
             # Check if component exists in the netlist
             components = netlist_data.get("components", {})
             if component_ref not in components:
-                print(f"Component {component_ref} not found in schematic")
+                logger.warning("Component %s not found in schematic", component_ref)
                 await ctx.info(f"Component {component_ref} not found in schematic")
                 return {
                     "success": False,
@@ -407,6 +412,6 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            print(f"Error finding component connections: {str(e)}", exc_info=True)
+            logger.error("Error finding component connections: %s", e, exc_info=True)
             await ctx.info(f"Error finding component connections: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -61,7 +61,7 @@ class SchematicParser:
                 self.content = f.read()
                 logger.debug("Successfully loaded schematic: %s", self.schematic_path)
         except Exception as e:
-            logger.error("Error reading schematic file: %s", e)
+            logger.error("Error reading schematic file: %s", e, exc_info=True)
             raise
 
     def parse(self) -> dict[str, Any]:
@@ -597,7 +597,7 @@ def extract_netlist(schematic_path: str) -> dict[str, Any]:
         parser = SchematicParser(schematic_path)
         return parser.parse()
     except Exception as e:
-        logger.error("Error extracting netlist: %s", e)
+        logger.error("Error extracting netlist: %s", e, exc_info=True)
         return {"error": str(e), "components": {}, "nets": {}, "component_count": 0, "net_count": 0}
 
 

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -53,15 +53,15 @@ class SchematicParser:
     def _load_schematic(self) -> None:
         """Load the schematic file content."""
         if not os.path.exists(self.schematic_path):
-            print(f"Schematic file not found: {self.schematic_path}")
+            logger.error("Schematic file not found: %s", self.schematic_path)
             raise FileNotFoundError(f"Schematic file not found: {self.schematic_path}")
 
         try:
             with open(self.schematic_path) as f:
                 self.content = f.read()
-                print(f"Successfully loaded schematic: {self.schematic_path}")
+                logger.debug("Successfully loaded schematic: %s", self.schematic_path)
         except Exception as e:
-            print(f"Error reading schematic file: {str(e)}")
+            logger.error("Error reading schematic file: %s", e)
             raise
 
     def parse(self) -> dict[str, Any]:
@@ -70,7 +70,7 @@ class SchematicParser:
         Returns:
             Dictionary with parsed netlist information
         """
-        print("Starting schematic parsing")
+        logger.info("Starting schematic parsing")
 
         # Extract symbols (components)
         self._extract_components()
@@ -110,8 +110,10 @@ class SchematicParser:
             "net_count": len(self.nets),
         }
 
-        print(
-            f"Schematic parsing complete: found {len(self.component_info)} components and {len(self.nets)} nets"
+        logger.info(
+            "Schematic parsing complete: found %d components and %d nets",
+            len(self.component_info),
+            len(self.nets),
         )
         return result
 
@@ -159,7 +161,7 @@ class SchematicParser:
 
     def _extract_components(self) -> None:
         """Extract component information from schematic."""
-        print("Extracting components")
+        logger.debug("Extracting components")
 
         # Extract all symbol expressions (components)
         symbols = self._extract_s_expressions(r"\(symbol\s+")
@@ -176,7 +178,7 @@ class SchematicParser:
                 ref = component.get("reference", "Unknown")
                 self.component_info[ref] = component
 
-        print(f"Extracted {len(self.components)} components")
+        logger.debug("Extracted %d components", len(self.components))
 
     def _parse_component(self, symbol_expr: str) -> dict[str, Any]:
         """Parse a component from a symbol S-expression.
@@ -231,7 +233,9 @@ class SchematicParser:
 
             return component
         except Exception as e:
-            print(f"Failed to parse component expression: {e}\nExpression:\n{symbol_expr}")
+            logger.warning(
+                "Failed to parse component expression: %s\nExpression:\n%s", e, symbol_expr
+            )
             return {}
 
     def _extract_wires(self, content: str) -> list[dict[str, Any]]:
@@ -321,7 +325,7 @@ class SchematicParser:
 
     def _extract_power_symbols(self) -> None:
         """Extract power symbol information from schematic."""
-        print("Extracting power symbols")
+        logger.debug("Extracting power symbols")
 
         # Extract all power symbol expressions
         power_symbols = self._extract_s_expressions(r'\(symbol\s+\(lib_id\s+"power:')
@@ -343,11 +347,11 @@ class SchematicParser:
                     }
                 )
 
-        print(f"Extracted {len(self.power_symbols)} power symbols")
+        logger.debug("Extracted %d power symbols", len(self.power_symbols))
 
     def _extract_no_connects(self) -> None:
         """Extract no-connect information from schematic."""
-        print("Extracting no-connects")
+        logger.debug("Extracting no-connects")
 
         # Extract all no-connect expressions
         no_connects = self._extract_s_expressions(r"\(no_connect\s+")
@@ -360,7 +364,7 @@ class SchematicParser:
                     {"x": float(xy_match.group(1)), "y": float(xy_match.group(2))}
                 )
 
-        print(f"Extracted {len(self.no_connects)} no-connects")
+        logger.debug("Extracted %d no-connects", len(self.no_connects))
 
     def _extract_lib_symbol_pins(self) -> None:
         """Extract pin positions from the lib_symbols section of the schematic.
@@ -575,7 +579,7 @@ def extract_netlist(schematic_path: str) -> dict[str, Any]:
                 or "symbol" in json_data
                 or ("version" in json_data and not content.startswith("("))
             ):
-                print(f"Detected JSON format schematic: {schematic_path}")
+                logger.debug("Detected JSON format schematic: %s", schematic_path)
                 return parse_json_schematic(json_data)
         except json.JSONDecodeError:
             # If it's not JSON, it should be an S-expression
@@ -589,11 +593,11 @@ def extract_netlist(schematic_path: str) -> dict[str, Any]:
                 }
 
         # Fall back to S-expression parser
-        print(f"Using S-expression parser for: {schematic_path}")
+        logger.info("Using S-expression parser for: %s", schematic_path)
         parser = SchematicParser(schematic_path)
         return parser.parse()
     except Exception as e:
-        print(f"Error extracting netlist: {str(e)}")
+        logger.error("Error extracting netlist: %s", e)
         return {"error": str(e), "components": {}, "nets": {}, "component_count": 0, "net_count": 0}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

Continues the print()→logging migration started in PR #49. Converts **101** `print()` calls across the five highest-volume modules:

| File | calls migrated |
|---|---|
| `kicad_mcp/resources/bom_resources.py` | 12 |
| `kicad_mcp/tools/bom_tools.py` | 29 |
| `kicad_mcp/tools/export_tools.py` | 25 |
| `kicad_mcp/tools/netlist_tools.py` | 20 |
| `kicad_mcp/utils/netlist_parser.py` | 15 |

Each module gets a top-level `logger = logging.getLogger(__name__)`. Levels chosen per-call: `debug` for verbose internals, `info` for progress, `warning` for recoverable issues, `error` for handled errors.

## Remaining work (follow-up PR)

`drc_tools.py`, `drc_impl/cli_drc.py`, `drc_history.py`, `kicad_api_detection.py`, `visual_testing.py`, `mock_renderer.py`, `text_to_schematic.py`, plus the DRC/netlist/pattern resource modules still have print() calls. Partially addresses #58 — issue will stay open for the follow-up.

## Test plan

- `uv run ruff check` passes
- `uv run pytest tests/ -q` → 394 passed, 2 skipped (skips are #2-related, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)