### PR TITLE
chore: add vulture dead-code detection (closes #39)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # KiCad MCP Makefile
 # Provides common development tasks using uv
 
-.PHONY: help install test test-unit test-integration coverage lint format clean dev run
+.PHONY: help install test test-unit test-integration coverage lint format clean dev run dead-code
 
 # Default target
 help:
@@ -57,6 +57,10 @@ lint:
 	uv run ruff check .
 	# Temporarily disabled mypy due to 200+ type errors - will fix separately
 	# uv run mypy kicad_mcp/
+
+# Detect unreachable / unused code
+dead-code:
+	uv run vulture
 
 # Format code
 format:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	@echo "Code Quality:"
 	@echo "  lint        - Run linting checks"
 	@echo "  format      - Format code"
+	@echo "  dead-code   - Detect unused / unreachable code with vulture"
 	@echo ""
 	@echo "Development:"
 	@echo "  run         - Run the MCP server"

--- a/kicad_mcp/server.py
+++ b/kicad_mcp/server.py
@@ -119,12 +119,12 @@ def register_signal_handlers(server: FastMCP) -> None:
         server: The FastMCP server instance
     """
 
-    def handle_exit_signal(signum: int, frame) -> None:
+    def handle_exit_signal(signum: int, _frame) -> None:
         """Handle system exit signals for graceful shutdown.
 
         Args:
             signum: Signal number received
-            frame: Current stack frame (unused)
+            _frame: Current stack frame (unused — required by signal protocol)
 
         Note:
             Calls run_cleanup_handlers(), shutdown_server(), then os._exit(0)
@@ -273,12 +273,12 @@ def setup_signal_handlers() -> None:
         Uses the module logger instead of logging directly.
     """
 
-    def signal_handler(signum: int, frame) -> None:
+    def signal_handler(signum: int, _frame) -> None:
         """Handle shutdown signals for test compatibility.
 
         Args:
             signum: Signal number received
-            frame: Current stack frame (unused)
+            _frame: Current stack frame (unused — required by signal protocol)
 
         Note:
             Calls cleanup_handler() then sys.exit(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "mypy>=1.8.0",
     "pre-commit>=3.0.0",
     "bandit>=1.7.0",  # Security linting for pre-commit hooks
+    "vulture>=2.11",  # Dead-code detection
 ]
 docs = [
     "sphinx>=7.0.0",
@@ -227,3 +228,20 @@ skips = ["B101", "B601", "B404", "B603", "B110", "B112"]  # Skip low-severity su
 
 [tool.bandit.assert_used]
 skips = ["*_test.py", "*/test_*.py"]
+
+[tool.vulture]
+# Dead-code detection. Run with `uv run vulture` or `make dead-code`.
+paths = ["kicad_mcp", "vulture_allowlist.py"]
+exclude = ["tests/", ".venv/", "build/", "dist/"]
+# 80% confidence threshold avoids most false positives while still flagging
+# genuinely unreachable code. Raise to reduce noise; lower for strict audits.
+min_confidence = 80
+sort_by_size = true
+ignore_decorators = [
+    "@mcp.tool",
+    "@mcp.resource",
+    "@mcp.prompt",
+    "@dataclass",
+    "@pytest.fixture",
+    "@pytest.mark.*",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
@@ -769,6 +769,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -812,6 +813,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.10.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "vulture", specifier = ">=2.11" },
 ]
 docs = [
     { name = "myst-parser", specifier = ">=2.0.0" },
@@ -2447,6 +2449,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload-time = "2025-05-08T17:58:23.811Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload-time = "2025-05-08T17:58:21.15Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -1,0 +1,31 @@
+"""Vulture allowlist for intentional "unused" names.
+
+Vulture reports anything it cannot prove is referenced. Several idioms in this
+codebase produce false positives — MCP tool/resource registrations referenced
+only by decorators, FastMCP parameters introspected at runtime, and dataclass
+fields consumed via serialization. List them here so `uv run vulture` stays
+signal-heavy.
+
+Any name added here should include a short comment explaining why it's needed.
+Prefer fixing real dead code over adding allowlist entries.
+"""
+
+# FastMCP-registered handler functions are only referenced via the @mcp.tool /
+# @mcp.resource / @mcp.prompt decorators, which vulture doesn't follow into the
+# runtime registry. The `ignore_decorators` config in pyproject.toml covers
+# most of these; anything leaking through goes here.
+
+# pytest fixtures and hooks — referenced by name via dependency injection
+_unused_pytest_fixtures = (
+    "pytest_collection_modifyitems",
+    "pytest_configure",
+)
+
+# Public API re-exports from __init__ modules — may appear unused within the
+# package but are part of the external surface.
+_unused_public_api: tuple[str, ...] = ()
+
+# signal.signal() callback signature requires (signum, frame); frame is
+# always unused by our handlers but cannot be renamed with a leading
+# underscore without breaking the signal protocol.
+frame = None

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -24,8 +24,3 @@ _unused_pytest_fixtures = (
 # Public API re-exports from __init__ modules — may appear unused within the
 # package but are part of the external surface.
 _unused_public_api: tuple[str, ...] = ()
-
-# signal.signal() callback signature requires (signum, frame); frame is
-# always unused by our handlers but cannot be renamed with a leading
-# underscore without breaking the signal protocol.
-frame = None


### PR DESCRIPTION
## Summary

Closes #39.

- Adds \`vulture>=2.11\` to the \`dev\` dependency group.
- Configures \`[tool.vulture]\` in \`pyproject.toml\` — \`min_confidence=80\`, paths limited to \`kicad_mcp/\` + the allowlist, and decorator ignores for \`@mcp.tool\` / \`@mcp.resource\` / \`@mcp.prompt\` / \`@dataclass\` / \`@pytest.*\` (common false-positive sources).
- Introduces \`vulture_allowlist.py\` for intentional \"unused\" names not expressible via decorator ignores.
- Adds a \`make dead-code\` target.
- Renames the unused \`frame\` params in the two signal-handler callbacks in \`kicad_mcp/server.py\` to \`_frame\` (leading underscore is the standard Python convention for signal-protocol params that can't be omitted).

## Current baseline

\`make dead-code\` → **0 findings**.

## Test plan

- \`uv run vulture\` exits 0
- \`uv run pytest tests/ -q\` → 394 passed, 2 skipped (pre-existing skips unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)