### PR TITLE
fix(sexpr): emit wires for shorthand connections with missing pin (closes #57)

### DIFF
--- a/kicad_mcp/utils/sexpr_handler.py
+++ b/kicad_mcp/utils/sexpr_handler.py
@@ -612,16 +612,12 @@ class SExpressionHandler:
                 return None
 
             # Register the connection with the pin mapper
-            connection_added = self.pin_mapper.add_connection(
+            self.pin_mapper.add_connection(
                 start_component,
                 start_pin,
                 end_component,
                 end_pin,
             )
-
-            if not connection_added:
-                # Log warning but continue with wire generation
-                pass
 
             start_x, start_y = start_pos
             end_x, end_y = end_pos

--- a/kicad_mcp/utils/sexpr_handler.py
+++ b/kicad_mcp/utils/sexpr_handler.py
@@ -5,6 +5,7 @@ This module provides a native Python implementation for generating KiCad S-expre
 without external dependencies, following KiCad's official schematic file format.
 """
 
+import logging
 from typing import Any
 import uuid
 
@@ -14,6 +15,8 @@ from kicad_mcp.utils.component_layout import ComponentLayoutManager
 from kicad_mcp.utils.pin_mapper import ComponentPinMapper
 from kicad_mcp.utils.version import KICAD_FILE_FORMAT_VERSION
 from kicad_mcp.utils.wire_router import RouteStrategy, RoutingObstacle, WireRouter
+
+logger = logging.getLogger(__name__)
 
 
 class SExpressionHandler:
@@ -586,23 +589,34 @@ class SExpressionHandler:
             key in connection
             for key in ["start_component", "start_pin", "end_component", "end_pin"]
         ):
-            # Pin-to-pin connection
-            start_pos = self.pin_mapper.get_pin_connection_point(
-                connection["start_component"], connection["start_pin"]
-            )
-            end_pos = self.pin_mapper.get_pin_connection_point(
-                connection["end_component"], connection["end_pin"]
-            )
+            # Pin-to-pin connection. Parsers (e.g. shorthand like "VCC -> R1.1")
+            # emit pin=None for references without an explicit pin number. Power
+            # symbols register a single pin "1", and "1" is a reasonable default
+            # for any single-pin reference, so fall back to "1" before lookup.
+            start_component = connection["start_component"]
+            end_component = connection["end_component"]
+            start_pin = connection["start_pin"] if connection["start_pin"] is not None else "1"
+            end_pin = connection["end_pin"] if connection["end_pin"] is not None else "1"
+
+            start_pos = self.pin_mapper.get_pin_connection_point(start_component, start_pin)
+            end_pos = self.pin_mapper.get_pin_connection_point(end_component, end_pin)
 
             if not start_pos or not end_pos:
+                logger.warning(
+                    "No pin position for %s.%s -> %s.%s — wire skipped",
+                    start_component,
+                    start_pin,
+                    end_component,
+                    end_pin,
+                )
                 return None
 
             # Register the connection with the pin mapper
             connection_added = self.pin_mapper.add_connection(
-                connection["start_component"],
-                connection["start_pin"],
-                connection["end_component"],
-                connection["end_pin"],
+                start_component,
+                start_pin,
+                end_component,
+                end_pin,
             )
 
             if not connection_added:

--- a/tests/integration/test_text_to_schematic_wires.py
+++ b/tests/integration/test_text_to_schematic_wires.py
@@ -92,8 +92,8 @@ def test_shorthand_connections_round_trip_through_netlist(tmp_path: Path) -> Non
 
     assert "error" not in netlist, f"netlist extraction reported error: {netlist.get('error')}"
     assert netlist.get("component_count", 0) >= 2
-    assert netlist.get("net_count", 0) >= 1, (
-        f"expected at least one net from shorthand connections; got {netlist}"
+    assert netlist.get("net_count", 0) >= 2, (
+        f"expected at least two nets (VCC and GND rails) from shorthand connections; got {netlist}"
     )
 
 

--- a/tests/integration/test_text_to_schematic_wires.py
+++ b/tests/integration/test_text_to_schematic_wires.py
@@ -1,0 +1,101 @@
+"""Integration tests covering wire emission when parsed connections omit pin numbers.
+
+Regression coverage for issue #57: shorthand references like ``VCC -> R1.1`` emit
+connections with ``start_pin=None``/``end_pin=None``. The S-expression handler
+previously dropped these silently, yielding schematics with no wires at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.tools.text_to_schematic import TextToSchematicParser
+from kicad_mcp.utils.netlist_parser import extract_netlist
+from kicad_mcp.utils.sexpr_service import get_sexpr_service
+
+VOLTAGE_DIVIDER = """
+circuit: Voltage Divider
+
+components:
+  R1 resistor 10k (100, 60)
+  R2 resistor 10k (100, 100)
+
+power:
+  VCC +5V (60, 40)
+  GND GND (60, 120)
+
+connections:
+  VCC -> R1.1
+  R1.2 -> R2.1
+  R2.2 -> GND
+"""
+
+
+def _generate_divider_sexpr() -> str:
+    parser = TextToSchematicParser()
+    circuit = parser.parse_simple_text(VOLTAGE_DIVIDER)
+
+    assert circuit.components, "expected components parsed from voltage divider fixture"
+    assert circuit.power_symbols, "expected power symbols parsed from voltage divider fixture"
+    assert len(circuit.connections) == 3
+
+    # At least one connection must carry pin=None to exercise the regression path.
+    assert any(c.start_pin is None or c.end_pin is None for c in circuit.connections)
+
+    components = [
+        {
+            "reference": c.reference,
+            "value": c.value,
+            "position": c.position,
+            "symbol_library": c.symbol_library,
+            "symbol_name": c.symbol_name,
+        }
+        for c in circuit.components
+    ]
+    power_symbols = [
+        {"reference": p.reference, "power_type": p.power_type, "position": p.position}
+        for p in circuit.power_symbols
+    ]
+    connections = [
+        {
+            "start_component": c.start_component,
+            "start_pin": c.start_pin,
+            "end_component": c.end_component,
+            "end_pin": c.end_pin,
+        }
+        for c in circuit.connections
+    ]
+
+    service = get_sexpr_service()
+    return service.generate_schematic(circuit.name, components, power_symbols, connections)
+
+
+def test_shorthand_connections_emit_wires() -> None:
+    """`VCC -> R1.1` style connections must produce wires, not be silently dropped."""
+    sexpr = _generate_divider_sexpr()
+    # KiCad emits wires with either "(wire " or "(wire\n" depending on pretty-print.
+    wire_count = sexpr.count("(wire\n") + sexpr.count("(wire ")
+    assert wire_count >= 3, (
+        f"expected at least 3 wires for the voltage divider; got {wire_count}:\n{sexpr}"
+    )
+
+
+def test_shorthand_connections_round_trip_through_netlist(tmp_path: Path) -> None:
+    """Wires emitted for shorthand connections must be visible to the netlist parser."""
+    sexpr = _generate_divider_sexpr()
+    schematic_path = tmp_path / "voltage_divider.kicad_sch"
+    schematic_path.write_text(sexpr)
+
+    netlist = extract_netlist(str(schematic_path))
+
+    assert "error" not in netlist, f"netlist extraction reported error: {netlist.get('error')}"
+    assert netlist.get("component_count", 0) >= 2
+    assert netlist.get("net_count", 0) >= 1, (
+        f"expected at least one net from shorthand connections; got {netlist}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -440,7 +440,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kicad-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

- Fix `_build_wire_sexpr` silently dropping wires when a parsed connection carries `start_pin=None` / `end_pin=None` — the exact case produced by shorthand references like `VCC -> R1.1` in the text-to-schematic parser (power symbols and single-pin references omit the pin number).
- Fall back to pin `\"1\"` when the incoming pin is `None`. Power symbols register a single pin `\"1\"`, and `\"1\"` is a reasonable default for any single-pin reference, so this resolves through the existing pin mapper without needing special-casing per component type.
- Log a warning via `logging.getLogger(__name__).warning(...)` when the mapper still fails to resolve a pin position, instead of silently dropping the wire. Future regressions will now surface in logs.

## Test plan

- [x] New integration test `tests/integration/test_text_to_schematic_wires.py` drives a voltage-divider fixture (`VCC -> R1.1`, `R1.2 -> R2.1`, `R2.2 -> GND`) through `TextToSchematicParser.parse_simple_text` and `SExpressionHandler.generate_schematic`, then asserts at least three `(wire ...)` entries in the emitted `.kicad_sch` and a non-empty net list from `extract_netlist`.
- [x] `uv run pytest tests/ -q --no-cov` — 396 passed, 2 skipped (pre-existing version-drift skips).
- [x] `uv run pytest tests/ --cov=kicad_mcp --cov-fail-under=37` — coverage gate holds.
- [x] `make lint` and `make format` clean.
- [ ] Manual: open generated `.kicad_sch` in KiCad 9+ to confirm wires render without \"older format\" warnings.

## Scope

Strictly the `pin=None` silent-drop bug. Explicit non-goals (tracked separately):

- Switching to `generate_schematic_with_intelligent_wiring` for routing.
- Adding junctions at wire intersections.
- Routing avoidance.

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)