### PR TITLE
fix(tools): add missing await to ctx.info() calls

### DIFF
--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -42,7 +42,7 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context) -> dict[str, Any]:
 
             # Report progress
             await ctx.report_progress(50, 100)
-            ctx.info("Running DRC using KiCad CLI...")
+            await ctx.info("Running DRC using KiCad CLI...")
 
             # Build the DRC command args (without kicad-cli executable)
             command_args = ["pcb", "drc", "--format", "json", "--output", output_file, pcb_file]
@@ -87,7 +87,7 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context) -> dict[str, Any]:
             violation_count = len(violations)
             print(f"DRC completed with {violation_count} violations")
             await ctx.report_progress(70, 100)
-            ctx.info(f"DRC completed with {violation_count} violations")
+            await ctx.info(f"DRC completed with {violation_count} violations")
 
             # Categorize violations by type
             error_types = {}

--- a/kicad_mcp/tools/drc_tools.py
+++ b/kicad_mcp/tools/drc_tools.py
@@ -91,13 +91,13 @@ def register_drc_tools(mcp: FastMCP) -> None:
 
         # Report progress to user
         await ctx.report_progress(10, 100)
-        ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
+        await ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
 
         # Run DRC using the appropriate approach
         drc_results = None
 
         print("Using kicad-cli for DRC")
-        ctx.info("Using KiCad CLI for DRC check...")
+        await ctx.info("Using KiCad CLI for DRC check...")
         drc_results = await run_drc_via_cli(pcb_file, ctx)
 
         # Process and save results if successful
@@ -111,15 +111,17 @@ def register_drc_tools(mcp: FastMCP) -> None:
                 drc_results["comparison"] = comparison
 
                 if comparison["change"] < 0:
-                    ctx.info(
+                    await ctx.info(
                         f"Great progress! You've fixed {abs(comparison['change'])} DRC violations since the last check."
                     )
                 elif comparison["change"] > 0:
-                    ctx.info(
+                    await ctx.info(
                         f"Found {comparison['change']} new DRC violations since the last check."
                     )
                 else:
-                    ctx.info("No change in the number of DRC violations since the last check.")
+                    await ctx.info(
+                        "No change in the number of DRC violations since the last check."
+                    )
         elif drc_results:
             pass
         else:

--- a/kicad_mcp/tools/pattern_tools.py
+++ b/kicad_mcp/tools/pattern_tools.py
@@ -47,34 +47,34 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             Dictionary with identified circuit patterns
         """
         if not os.path.exists(schematic_path):
-            ctx.info(f"Schematic file not found: {schematic_path}")
+            await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
         # Report progress
         await ctx.report_progress(10, 100)
-        ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
+        await ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
 
         try:
             # Extract netlist information
             await ctx.report_progress(20, 100)
-            ctx.info("Parsing schematic structure...")
+            await ctx.info("Parsing schematic structure...")
 
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
-                ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+                await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
             # Analyze components and nets
             await ctx.report_progress(30, 100)
-            ctx.info("Analyzing components and connections...")
+            await ctx.info("Analyzing components and connections...")
 
             components = netlist_data.get("components", {})
             nets = netlist_data.get("nets", {})
 
             # Start pattern recognition
             await ctx.report_progress(50, 100)
-            ctx.info("Identifying circuit patterns...")
+            await ctx.info("Identifying circuit patterns...")
 
             identified_patterns = {
                 "power_supply_circuits": [],
@@ -133,12 +133,14 @@ def register_pattern_tools(mcp: FastMCP) -> None:
 
             # Complete progress
             await ctx.report_progress(100, 100)
-            ctx.info(f"Pattern recognition complete. Found {total_patterns} circuit patterns.")
+            await ctx.info(
+                f"Pattern recognition complete. Found {total_patterns} circuit patterns."
+            )
 
             return result
 
         except Exception as e:
-            ctx.info(f"Error identifying circuit patterns: {str(e)}")
+            await ctx.info(f"Error identifying circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
@@ -153,7 +155,7 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             Dictionary with identified circuit patterns
         """
         if not os.path.exists(project_path):
-            ctx.info(f"Project not found: {project_path}")
+            await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
@@ -164,11 +166,11 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             files = get_project_files(project_path)
 
             if "schematic" not in files:
-                ctx.info("Schematic file not found in project")
+                await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
-            ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
+            await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Identify patterns in the schematic
             result = await identify_circuit_patterns(schematic_path, ctx)
@@ -180,5 +182,5 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             return result
 
         except Exception as e:
-            ctx.info(f"Error analyzing project circuit patterns: {str(e)}")
+            await ctx.info(f"Error analyzing project circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Summary

- Adds missing `await` to 19 `ctx.info()` calls across `drc_tools.py`, `pattern_tools.py`, and `drc_impl/cli_drc.py`
- Without `await`, these coroutines were silently dropped and MCP progress messages never reached the client

Closes #75

## Test plan

- [x] `uv run pytest tests/ -x -q` passes (412 tests)
- [x] `grep -rn 'ctx\.info(' kicad_mcp/ | grep -v 'await'` returns no matches
- [x] Pre-commit hooks pass (ruff check, ruff format, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)