### PR TITLE
fix(tests): resolve skipped tests and collection warnings

### DIFF
--- a/tests/fixtures/sample_schematics/sexpr_schematic.kicad_sch
+++ b/tests/fixtures/sample_schematics/sexpr_schematic.kicad_sch
@@ -1,6 +1,6 @@
 (kicad_sch
-  (version 20230121)
-  (generator eeschema)
+  (version 20241201)
+  (generator "kicad-mcp")
   (uuid "12345678-1234-1234-1234-123456789abc")
   (paper "A4")
 

--- a/tests/system/run_http_tests.py
+++ b/tests/system/run_http_tests.py
@@ -15,7 +15,7 @@ import uvicorn
 from kicad_mcp.server import create_server
 from tests.system.http_client import HTTPClientError, create_http_client, mcp_tool_call
 from tests.system.temp_manager import TempDirectoryManager
-from tests.system.test_config import TestConfig, TestConfigLoader
+from tests.system.test_config import ConfigHelper, ConfigLoaderHelper
 from tests.system.validators import ValidationRunner
 
 
@@ -75,7 +75,7 @@ class HTTPTestRunner:
         self.http_backend = http_backend
         self.verbose = verbose
 
-        self.config_loader = TestConfigLoader()
+        self.config_loader = ConfigLoaderHelper()
         self.validation_runner = ValidationRunner()
         self.temp_manager = TempDirectoryManager()
 
@@ -126,7 +126,7 @@ class HTTPTestRunner:
 
         return False
 
-    def run_single_test(self, config: TestConfig) -> TestResult:
+    def run_single_test(self, config: ConfigHelper) -> TestResult:
         """Run a single test configuration.
 
         Args:

--- a/tests/system/test_config.py
+++ b/tests/system/test_config.py
@@ -27,11 +27,8 @@ class ValidationConfig(BaseModel):
     format: str = Field(None, description="Expected file format")
 
 
-class TestConfig(BaseModel):
+class ConfigHelper(BaseModel):
     """Complete test configuration."""
-
-    # Prevent pytest from collecting this Pydantic model as a test class
-    __test__ = False
 
     test_name: str = Field(..., description="Unique name for the test")
     description: str = Field(..., description="Human-readable test description")
@@ -45,17 +42,14 @@ class TestConfig(BaseModel):
     skip_cleanup: bool = Field(default=False, description="Skip cleanup for debugging")
 
 
-class TestConfigLoader:
+class ConfigLoaderHelper:
     """Loads and validates test configurations from JSON files."""
-
-    # Prevent pytest from collecting this helper class as a test class
-    __test__ = False
 
     def __init__(self):
         """Initialize test config loader."""
-        self.loaded_configs: dict[str, TestConfig] = {}
+        self.loaded_configs: dict[str, ConfigHelper] = {}
 
-    def load_config_file(self, config_path: str | Path) -> TestConfig:
+    def load_config_file(self, config_path: str | Path) -> ConfigHelper:
         """Load test configuration from JSON file.
 
         Args:
@@ -83,13 +77,13 @@ class TestConfigLoader:
             ) from e
 
         try:
-            config = TestConfig(**config_data)
+            config = ConfigHelper(**config_data)
             self.loaded_configs[config.test_name] = config
             return config
         except ValidationError as e:
             raise ValidationError(f"Invalid configuration in {config_path}: {e}") from e
 
-    def load_config_directory(self, config_dir: str | Path) -> dict[str, TestConfig]:
+    def load_config_directory(self, config_dir: str | Path) -> dict[str, ConfigHelper]:
         """Load all test configurations from a directory.
 
         Args:
@@ -116,7 +110,7 @@ class TestConfigLoader:
 
         return configs
 
-    def validate_config(self, config: TestConfig) -> list[str]:
+    def validate_config(self, config: ConfigHelper) -> list[str]:
         """Validate a test configuration for common issues.
 
         Args:
@@ -151,7 +145,7 @@ class TestConfigLoader:
 
         return issues
 
-    def get_config(self, test_name: str) -> TestConfig | None:
+    def get_config(self, test_name: str) -> ConfigHelper | None:
         """Get a loaded configuration by name.
 
         Args:


### PR DESCRIPTION
## Summary

- Update `sexpr_schematic.kicad_sch` fixture version 20230121 → 20241201 to unskip 2 format version tests
- Rename `TestConfig` → `ConfigHelper` and `TestConfigLoader` → `ConfigLoaderHelper` to prevent pytest collection warnings

Closes #61 (items 1 and 2). Coverage threshold (item 3) deferred to #47.

## Test plan

- [x] All 412 tests pass
- [x] Previously skipped tests in `test_kicad_file_format_versions.py` now run and pass
- [x] No pytest collection warnings for renamed classes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)