### PR TITLE
refactor: migrate remaining print() calls to logging

### DIFF
--- a/kicad_mcp/resources/drc_resources.py
+++ b/kicad_mcp/resources/drc_resources.py
@@ -3,6 +3,7 @@
 Registers ``kicad://drc/`` resources for DRC reports and history.
 """
 
+import logging
 import os
 
 from fastmcp import FastMCP
@@ -10,6 +11,8 @@ from fastmcp import FastMCP
 from kicad_mcp.tools.drc_impl.cli_drc import run_drc_via_cli
 from kicad_mcp.utils.drc_history import get_drc_history
 from kicad_mcp.utils.file_utils import get_project_files
+
+logger = logging.getLogger(__name__)
 
 
 def register_drc_resources(mcp: FastMCP) -> None:
@@ -29,7 +32,7 @@ def register_drc_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted DRC history report
         """
-        print(f"Generating DRC history report for project: {project_path}")
+        logger.info("Generating DRC history report for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -150,7 +153,7 @@ def register_drc_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted DRC report
         """
-        print(f"Generating DRC report for project: {project_path}")
+        logger.info("Generating DRC report for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -161,7 +164,7 @@ def register_drc_resources(mcp: FastMCP) -> None:
             return "PCB file not found in project"
 
         pcb_file = files["pcb"]
-        print(f"Found PCB file: {pcb_file}")
+        logger.debug("Found PCB file: %s", pcb_file)
 
         # Try to run DRC via command line
         drc_results = await run_drc_via_cli(pcb_file)

--- a/kicad_mcp/resources/netlist_resources.py
+++ b/kicad_mcp/resources/netlist_resources.py
@@ -4,12 +4,15 @@ Registers ``kicad://netlist/`` and ``kicad://component/`` resources for
 netlist reports and individual component connection details.
 """
 
+import logging
 import os
 
 from fastmcp import FastMCP
 
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.netlist_parser import analyze_netlist, extract_netlist
+
+logger = logging.getLogger(__name__)
 
 
 def register_netlist_resources(mcp: FastMCP) -> None:
@@ -29,7 +32,7 @@ def register_netlist_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted netlist report
         """
-        print(f"Generating netlist report for schematic: {schematic_path}")
+        logger.info("Generating netlist report for schematic: %s", schematic_path)
 
         if not os.path.exists(schematic_path):
             return f"Schematic file not found: {schematic_path}"
@@ -135,7 +138,7 @@ def register_netlist_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted netlist report
         """
-        print(f"Generating netlist report for project: {project_path}")
+        logger.info("Generating netlist report for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -148,7 +151,7 @@ def register_netlist_resources(mcp: FastMCP) -> None:
                 return "Schematic file not found in project"
 
             schematic_path = files["schematic"]
-            print(f"Found schematic file: {schematic_path}")
+            logger.debug("Found schematic file: %s", schematic_path)
 
             # Get the netlist resource for this schematic
             return get_netlist_resource(schematic_path)  # ty: ignore[call-non-callable]
@@ -167,7 +170,9 @@ def register_netlist_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted component report
         """
-        print(f"Generating component report for {component_ref} in schematic: {schematic_path}")
+        logger.info(
+            "Generating component report for %s in schematic: %s", component_ref, schematic_path
+        )
 
         if not os.path.exists(schematic_path):
             return f"Schematic file not found: {schematic_path}"

--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -4,6 +4,7 @@ Runs ``kicad-cli pcb drc`` and parses the JSON report.
 """
 
 import json
+import logging
 import os
 import tempfile
 from typing import Any
@@ -12,6 +13,8 @@ from fastmcp import Context
 
 from kicad_mcp.utils.kicad_cli import KiCadCLIError, find_kicad_cli
 from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
+
+logger = logging.getLogger(__name__)
 
 
 async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str, Any]:
@@ -35,7 +38,7 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
             # Find kicad-cli executable
             kicad_cli = find_kicad_cli()
             if not kicad_cli:
-                print("kicad-cli not found in PATH or common installation locations")
+                logger.warning("kicad-cli not found in PATH or common installation locations")
                 results["error"] = (
                     "kicad-cli not found. Please ensure KiCad 9.0+ is installed and kicad-cli is available."
                 )
@@ -49,7 +52,7 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
             # Build the DRC command args (without kicad-cli executable)
             command_args = ["pcb", "drc", "--format", "json", "--output", output_file, pcb_file]
 
-            print("Running DRC command via SecureSubprocessRunner")
+            logger.debug("Running DRC command via SecureSubprocessRunner")
             try:
                 runner = get_subprocess_runner()
                 process = runner.run_kicad_command(
@@ -58,20 +61,20 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
                     output_files=[output_file],
                 )
             except (SecureSubprocessError, KiCadCLIError) as e:
-                print(f"DRC command failed: {e}")
+                logger.error("DRC command failed: %s", e)
                 results["error"] = f"DRC command failed: {e}"
                 return results
 
             # Check if the command was successful
             if process.returncode != 0:
-                print(f"DRC command failed with code {process.returncode}")
-                print(f"Error output: {process.stderr}")
+                logger.error("DRC command failed with code %d", process.returncode)
+                logger.error("Error output: %s", process.stderr)
                 results["error"] = f"DRC command failed: {process.stderr}"
                 return results
 
             # Check if the output file was created
             if not os.path.exists(output_file):
-                print("DRC report file not created")
+                logger.error("DRC report file not created")
                 results["error"] = "DRC report file not created"
                 return results
 
@@ -80,14 +83,14 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
                 try:
                     drc_report = json.load(f)
                 except json.JSONDecodeError:
-                    print("Failed to parse DRC report JSON")
+                    logger.error("Failed to parse DRC report JSON")
                     results["error"] = "Failed to parse DRC report JSON"
                     return results
 
             # Process the DRC report
             violations = drc_report.get("violations", [])
             violation_count = len(violations)
-            print(f"DRC completed with {violation_count} violations")
+            logger.info("DRC completed with %d violations", violation_count)
             if ctx:
                 await ctx.report_progress(70, 100)
                 await ctx.info(f"DRC completed with {violation_count} violations")
@@ -115,6 +118,6 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
             return results
 
     except Exception as e:
-        print(f"Error in CLI DRC: {e!s}")
+        logger.error("Error in CLI DRC: %s", e, exc_info=True)
         results["error"] = f"Error in CLI DRC: {str(e)}"
         return results

--- a/kicad_mcp/tools/drc_tools.py
+++ b/kicad_mcp/tools/drc_tools.py
@@ -3,6 +3,7 @@
 Registers MCP tools for running DRC checks and viewing DRC history.
 """
 
+import logging
 import os
 from typing import Any
 
@@ -12,6 +13,8 @@ from fastmcp import Context, FastMCP
 from kicad_mcp.tools.drc_impl.cli_drc import run_drc_via_cli
 from kicad_mcp.utils.drc_history import compare_with_previous, get_drc_history, save_drc_result
 from kicad_mcp.utils.file_utils import get_project_files
+
+logger = logging.getLogger(__name__)
 
 
 def register_drc_tools(mcp: FastMCP) -> None:
@@ -31,10 +34,10 @@ def register_drc_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with DRC history entries
         """
-        print(f"Getting DRC history for project: {project_path}")
+        logger.info("Getting DRC history for project: %s", project_path)
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Get history entries
@@ -75,20 +78,20 @@ def register_drc_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with DRC results and statistics
         """
-        print(f"Running DRC check for project: {project_path}")
+        logger.info("Running DRC check for project: %s", project_path)
 
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Get PCB file from project
         files = get_project_files(project_path)
         if "pcb" not in files:
-            print("PCB file not found in project")
+            logger.warning("PCB file not found in project")
             return {"success": False, "error": "PCB file not found in project"}
 
         pcb_file = files["pcb"]
-        print(f"Found PCB file: {pcb_file}")
+        logger.debug("Found PCB file: %s", pcb_file)
 
         # Report progress to user
         await ctx.report_progress(10, 100)
@@ -97,7 +100,7 @@ def register_drc_tools(mcp: FastMCP) -> None:
         # Run DRC using the appropriate approach
         drc_results = None
 
-        print("Using kicad-cli for DRC")
+        logger.debug("Using kicad-cli for DRC")
         await ctx.info("Using KiCad CLI for DRC check...")
         drc_results = await run_drc_via_cli(pcb_file, ctx)
 

--- a/kicad_mcp/tools/text_to_schematic.py
+++ b/kicad_mcp/tools/text_to_schematic.py
@@ -5,6 +5,7 @@ Provides MermaidJS-like syntax for describing circuits that get converted to KiC
 """
 
 from dataclasses import dataclass
+import logging
 import os
 import re
 from typing import Any
@@ -15,6 +16,8 @@ import yaml
 from kicad_mcp.utils.boundary_validator import BoundaryValidator
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.sexpr_service import get_sexpr_service
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -283,7 +286,7 @@ class TextToSchematicParser:
             )
 
         except Exception as e:
-            print(f"Error parsing component '{comp_desc}': {e}")
+            logger.error("Error parsing component '%s': %s", comp_desc, e)
             return None
 
     def _parse_structured_component(self, comp_data: dict) -> Component | None:
@@ -319,7 +322,7 @@ class TextToSchematicParser:
             )
 
         except Exception as e:
-            print(f"Error parsing structured component {comp_data}: {e}")
+            logger.error("Error parsing structured component %s: %s", comp_data, e)
             return None
 
     def _parse_component_simple(self, line: str) -> Component | None:

--- a/kicad_mcp/utils/drc_history.py
+++ b/kicad_mcp/utils/drc_history.py
@@ -6,10 +6,13 @@ This will allow users to compare DRC results over time.
 
 from datetime import datetime
 import json
+import logging
 import os
 import platform
 import time
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Directory for storing DRC history
 if platform.system() == "Windows":
@@ -72,7 +75,7 @@ def save_drc_result(project_path: str, drc_result: dict[str, Any]) -> None:
             with open(history_path) as f:
                 history = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
-            print(f"Error loading DRC history: {str(e)}")
+            logger.error("Error loading DRC history: %s", e)
 
     # Add new entry and save
     history["entries"].append(history_entry)
@@ -86,9 +89,9 @@ def save_drc_result(project_path: str, drc_result: dict[str, Any]) -> None:
     try:
         with open(history_path, "w") as f:
             json.dump(history, f, indent=2)
-        print(f"Saved DRC history entry to {history_path}")
+        logger.info("Saved DRC history entry to %s", history_path)
     except OSError as e:
-        print(f"Error saving DRC history: {str(e)}")
+        logger.error("Error saving DRC history: %s", e)
 
 
 def get_drc_history(project_path: str) -> list[dict[str, Any]]:
@@ -103,7 +106,7 @@ def get_drc_history(project_path: str) -> list[dict[str, Any]]:
     history_path = get_project_history_path(project_path)
 
     if not os.path.exists(history_path):
-        print(f"No DRC history found for {project_path}")
+        logger.debug("No DRC history found for %s", project_path)
         return []
 
     try:
@@ -117,7 +120,7 @@ def get_drc_history(project_path: str) -> list[dict[str, Any]]:
 
         return entries
     except (OSError, json.JSONDecodeError) as e:
-        print(f"Error reading DRC history: {str(e)}")
+        logger.error("Error reading DRC history: %s", e)
         return []
 
 

--- a/kicad_mcp/utils/kicad_api_detection.py
+++ b/kicad_mcp/utils/kicad_api_detection.py
@@ -3,11 +3,14 @@
 Checks for a working ``kicad-cli`` binary in PATH or common install locations.
 """
 
+import logging
 import os
 import shutil
 
 from kicad_mcp.config import system
 from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
+
+logger = logging.getLogger(__name__)
 
 
 def check_for_cli_api() -> bool:
@@ -34,7 +37,7 @@ def check_for_cli_api() -> bool:
                     allowed_commands=[kicad_cli],
                 )
                 if result.returncode == 0:
-                    print(f"Found working kicad-cli: {kicad_cli}")
+                    logger.info("Found working kicad-cli: %s", kicad_cli)
                     return True
             except SecureSubprocessError:
                 pass
@@ -63,12 +66,12 @@ def check_for_cli_api() -> bool:
         # Check each potential path
         for path in potential_paths:
             if os.path.exists(path) and os.access(path, os.X_OK):
-                print(f"Found kicad-cli at common location: {path}")
+                logger.info("Found kicad-cli at common location: %s", path)
                 return True
 
-        print("KiCad CLI API is not available")
+        logger.info("KiCad CLI API is not available")
         return False
 
     except Exception as e:
-        print(f"Error checking for KiCad CLI API: {str(e)}")
+        logger.error("Error checking for KiCad CLI API: %s", e)
         return False

--- a/kicad_mcp/utils/mock_renderer.py
+++ b/kicad_mcp/utils/mock_renderer.py
@@ -3,9 +3,12 @@ Mock schematic renderer for development and testing when KiCad CLI is not availa
 Creates simple SVG representations of schematics for visualization testing.
 """
 
+import logging
 import os
 import re
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class MockSchematicRenderer:
@@ -317,7 +320,7 @@ class MockSchematicRenderer:
             return True
 
         except Exception as e:
-            print(f"Error rendering schematic: {e}")
+            logger.error("Error rendering schematic: %s", e)
             return False
 
 
@@ -368,13 +371,13 @@ if __name__ == "__main__":
     output_dir = "tests/visual_output"
 
     if os.path.exists(schematic_file):
-        print(f"🔧 Testing mock renderer with: {schematic_file}")
+        logger.info("Testing mock renderer with: %s", schematic_file)
 
         screenshot = create_mock_schematic_screenshot(schematic_file, output_dir)
         if screenshot:
-            print(f"✅ Mock screenshot created: {screenshot}")
+            logger.info("Mock screenshot created: %s", screenshot)
         else:
-            print("❌ Mock screenshot failed")
+            logger.error("Mock screenshot failed")
     else:
-        print(f"⚠️  Test schematic not found: {schematic_file}")
-        print("Run test_visualization_standalone.py first to create it")
+        logger.warning("Test schematic not found: %s", schematic_file)
+        logger.info("Run test_visualization_standalone.py first to create it")

--- a/kicad_mcp/utils/visual_testing.py
+++ b/kicad_mcp/utils/visual_testing.py
@@ -4,9 +4,12 @@ Provides functions for screenshot comparison and visual regression testing.
 """
 
 import asyncio
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class VisualTestUtils:
@@ -74,7 +77,7 @@ class VisualTestUtils:
             return png_file
 
         except Exception as e:
-            print(f"Error capturing screenshot: {e}")
+            logger.error("Error capturing screenshot: %s", e)
             return None
 
     def list_test_screenshots(self) -> list[str]:
@@ -105,7 +108,7 @@ class VisualTestUtils:
                     file_path.unlink()
                     cleaned_count += 1
                 except Exception as e:
-                    print(f"Error cleaning up {file_path}: {e}")
+                    logger.warning("Error cleaning up %s: %s", file_path, e)
 
         # Also clean up empty directories
         for dir_path in self.output_dir.rglob("*"):
@@ -113,7 +116,7 @@ class VisualTestUtils:
                 try:
                     dir_path.rmdir()
                 except Exception as e:
-                    print(f"Error removing empty directory {dir_path}: {e}")
+                    logger.warning("Error removing empty directory %s: %s", dir_path, e)
 
         return cleaned_count
 
@@ -200,8 +203,8 @@ class VisualTestUtils:
 
 async def test_visualization_tools():
     """Test the visualization tools with example projects."""
-    print("🔧 Testing KiCad Visualization Tools")
-    print("=" * 40)
+    logger.info("Testing KiCad Visualization Tools")
+    logger.info("=" * 40)
 
     visual_utils = VisualTestUtils()
     test_results = []
@@ -209,7 +212,7 @@ async def test_visualization_tools():
     # Test 1: LED Blinker Example
     led_project = "led_blinker_test_output/led_blinker_test.kicad_pro"
     if os.path.exists(led_project):
-        print("\n1. Testing LED Blinker visualization...")
+        logger.info("1. Testing LED Blinker visualization...")
         screenshot = await visual_utils.capture_project_screenshot(led_project, "led_blinker")
 
         if screenshot and os.path.exists(screenshot):
@@ -220,7 +223,7 @@ async def test_visualization_tools():
                     "screenshot": screenshot,
                 }
             )
-            print(f"✅ LED Blinker screenshot: {screenshot}")
+            logger.info("LED Blinker screenshot: %s", screenshot)
         else:
             test_results.append(
                 {
@@ -229,14 +232,14 @@ async def test_visualization_tools():
                     "error": "Failed to generate screenshot",
                 }
             )
-            print("❌ LED Blinker screenshot failed")
+            logger.error("LED Blinker screenshot failed")
     else:
-        print(f"⚠️  LED Blinker project not found: {led_project}")
+        logger.warning("LED Blinker project not found: %s", led_project)
 
     # Test 2: ESP32 Example
     esp32_project = "esp32_dev_board_example/esp32_dev_board.kicad_pro"
     if os.path.exists(esp32_project):
-        print("\n2. Testing ESP32 visualization...")
+        logger.info("2. Testing ESP32 visualization...")
         screenshot = await visual_utils.capture_project_screenshot(esp32_project, "esp32_dev_board")
 
         if screenshot and os.path.exists(screenshot):
@@ -247,7 +250,7 @@ async def test_visualization_tools():
                     "screenshot": screenshot,
                 }
             )
-            print(f"✅ ESP32 screenshot: {screenshot}")
+            logger.info("ESP32 screenshot: %s", screenshot)
         else:
             test_results.append(
                 {
@@ -256,26 +259,26 @@ async def test_visualization_tools():
                     "error": "Failed to generate screenshot",
                 }
             )
-            print("❌ ESP32 screenshot failed")
+            logger.error("ESP32 screenshot failed")
     else:
-        print(f"⚠️  ESP32 project not found: {esp32_project}")
+        logger.warning("ESP32 project not found: %s", esp32_project)
 
     # Generate test report
     if test_results:
         report_path = visual_utils.create_test_report(test_results)
-        print(f"\n📊 Test report generated: {report_path}")
+        logger.info("Test report generated: %s", report_path)
 
         # Summary
         success_count = sum(1 for result in test_results if result.get("success", False))
         total_count = len(test_results)
-        print(f"\n📈 Results: {success_count}/{total_count} tests passed")
+        logger.info("Results: %d/%d tests passed", success_count, total_count)
 
         if success_count == total_count:
-            print("🎉 All visualization tests passed!")
+            logger.info("All visualization tests passed!")
         else:
-            print("⚠️  Some visualization tests failed")
+            logger.warning("Some visualization tests failed")
     else:
-        print("\n⚠️  No test projects found to visualize")
+        logger.warning("No test projects found to visualize")
 
     return test_results
 


### PR DESCRIPTION
## Summary

Completes the migration started in PR #68 / #49. Replaces ~58 remaining `print()` calls with appropriate `logging` calls across 9 files:

- `tools/text_to_schematic.py` (2)
- `tools/drc_impl/cli_drc.py` (10)
- `tools/drc_tools.py` (7)
- `resources/netlist_resources.py` (5)
- `resources/drc_resources.py` (3)
- `utils/mock_renderer.py` (5)
- `utils/visual_testing.py` (16)
- `utils/drc_history.py` (6)
- `utils/kicad_api_detection.py` (4)

Log levels chosen contextually: `debug` for verbose/discovery, `info` for status, `warning` for missing resources, `error` for failures.

Closes #58

## Test plan

- [x] All 412 tests pass
- [x] Pre-commit hooks pass (ruff check/format, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)