### PR TITLE
docs: add Google-style docstrings to remaining modules

### DIFF
--- a/kicad_mcp/prompts/__init__.py
+++ b/kicad_mcp/prompts/__init__.py
@@ -1,3 +1,5 @@
-"""
-Prompt templates for KiCad MCP Server.
+"""Prompt templates for KiCad MCP Server.
+
+Each sub-module registers MCP prompts that guide users through
+common KiCad workflows (BOM analysis, circuit creation, DRC, etc.).
 """

--- a/kicad_mcp/prompts/bom_prompts.py
+++ b/kicad_mcp/prompts/bom_prompts.py
@@ -1,5 +1,6 @@
-"""
-BOM-related prompt templates for KiCad.
+"""BOM-related prompt templates for KiCad.
+
+Provides prompts for component analysis, cost estimation, BOM export, and sourcing.
 """
 
 from fastmcp import FastMCP

--- a/kicad_mcp/prompts/circuit_prompts.py
+++ b/kicad_mcp/prompts/circuit_prompts.py
@@ -1,5 +1,7 @@
-"""
-Prompt templates for circuit creation in KiCad.
+"""Prompt templates for circuit creation in KiCad.
+
+Provides guided prompts for LED circuits, power supplies, microcontrollers,
+amplifiers, filters, sensor interfaces, and troubleshooting.
 """
 
 from fastmcp import FastMCP

--- a/kicad_mcp/prompts/drc_prompt.py
+++ b/kicad_mcp/prompts/drc_prompt.py
@@ -1,5 +1,6 @@
-"""
-DRC prompt templates for KiCad PCB design.
+"""DRC prompt templates for KiCad PCB design.
+
+Provides prompts for fixing DRC violations and creating custom design rules.
 """
 
 from fastmcp import FastMCP

--- a/kicad_mcp/prompts/pattern_prompts.py
+++ b/kicad_mcp/prompts/pattern_prompts.py
@@ -1,5 +1,7 @@
-"""
-Prompt templates for circuit pattern analysis in KiCad.
+"""Prompt templates for circuit pattern analysis in KiCad.
+
+Provides prompts for identifying, analyzing, and comparing circuit patterns
+such as power supplies, amplifiers, sensors, and microcontroller connections.
 """
 
 from fastmcp import FastMCP

--- a/kicad_mcp/prompts/templates.py
+++ b/kicad_mcp/prompts/templates.py
@@ -1,5 +1,7 @@
-"""
-Prompt templates for KiCad interactions.
+"""Prompt templates for KiCad interactions.
+
+Provides general-purpose prompts for component creation, PCB debugging,
+and manufacturing preparation.
 """
 
 from fastmcp import FastMCP

--- a/kicad_mcp/resources/__init__.py
+++ b/kicad_mcp/resources/__init__.py
@@ -1,3 +1,5 @@
-"""
-Resource handlers for KiCad MCP Server.
+"""Resource handlers for KiCad MCP Server.
+
+Each sub-module registers MCP resources that expose project data
+(BOM, DRC, netlist, patterns, files) as addressable ``kicad://`` URIs.
 """

--- a/kicad_mcp/resources/bom_resources.py
+++ b/kicad_mcp/resources/bom_resources.py
@@ -1,5 +1,6 @@
-"""
-Bill of Materials (BOM) resources for KiCad projects.
+"""Bill of Materials (BOM) resources for KiCad projects.
+
+Registers ``kicad://bom/`` resources that return Markdown, CSV, and JSON BOM reports.
 """
 
 import json

--- a/kicad_mcp/resources/drc_resources.py
+++ b/kicad_mcp/resources/drc_resources.py
@@ -1,5 +1,6 @@
-"""
-Design Rule Check (DRC) resources for KiCad PCB files.
+"""Design Rule Check (DRC) resources for KiCad PCB files.
+
+Registers ``kicad://drc/`` resources for DRC reports and history.
 """
 
 import os

--- a/kicad_mcp/resources/files.py
+++ b/kicad_mcp/resources/files.py
@@ -1,5 +1,6 @@
-"""
-File content resources for KiCad files.
+"""File content resources for KiCad files.
+
+Registers ``kicad://schematic/`` resources that return schematic component summaries.
 """
 
 import os

--- a/kicad_mcp/resources/netlist_resources.py
+++ b/kicad_mcp/resources/netlist_resources.py
@@ -1,5 +1,7 @@
-"""
-Netlist resources for KiCad schematics.
+"""Netlist resources for KiCad schematics.
+
+Registers ``kicad://netlist/`` and ``kicad://component/`` resources for
+netlist reports and individual component connection details.
 """
 
 import os

--- a/kicad_mcp/resources/pattern_resources.py
+++ b/kicad_mcp/resources/pattern_resources.py
@@ -1,5 +1,7 @@
-"""
-Circuit pattern recognition resources for KiCad schematics.
+"""Circuit pattern recognition resources for KiCad schematics.
+
+Registers ``kicad://patterns/`` resources that return Markdown reports
+of identified circuit blocks.
 """
 
 import os

--- a/kicad_mcp/resources/projects.py
+++ b/kicad_mcp/resources/projects.py
@@ -1,5 +1,6 @@
-"""
-Project listing and information resources.
+"""Project listing and information resources.
+
+Registers ``kicad://project/`` resources for project details and file listings.
 """
 
 import os

--- a/kicad_mcp/tools/__init__.py
+++ b/kicad_mcp/tools/__init__.py
@@ -1,9 +1,6 @@
-"""
-Tool handlers for KiCad MCP Server.
+"""Tool handlers for KiCad MCP Server.
 
-This package includes:
-- Project management tools
-- Analysis tools
-- Export tools (BOM extraction, PCB thumbnail generation)
-- DRC tools
+Each sub-module registers MCP tools for a specific domain:
+project management, analysis, export, DRC, BOM, netlist,
+circuit creation, pattern recognition, and visualization.
 """

--- a/kicad_mcp/tools/analysis_tools.py
+++ b/kicad_mcp/tools/analysis_tools.py
@@ -1,14 +1,6 @@
-"""
-Analysis and validation tools for KiCad projects.
+"""Analysis and validation tools for KiCad projects.
 
-This module provides utility functions that can be registered with the FastMCP
-server to analyze and validate the structure and contents of KiCad projects.
-
-Functions:
-    - register_analysis_tools: Registers analysis functions like project validation.
-
-Usage:
-    This module is intended to be used by the MCP server via tool registration.
+Registers MCP tools for validating project structure and file integrity.
 """
 
 import os
@@ -51,11 +43,6 @@ def register_analysis_tools(mcp: FastMCP) -> None:
                 - issues (list[str] | None): List of issues found, or None if valid.
                 - files_found (list[str]): Keys of detected project files.
 
-        Raises:
-            This function handles exceptions internally and does not raise errors.
-
-        Time Complexity:
-            O(n) where n is the number of files in the project directory.
         """
         if not os.path.exists(project_path):
             return {"valid": False, "error": f"Project not found: {project_path}"}

--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -1,5 +1,7 @@
-"""
-Bill of Materials (BOM) processing tools for KiCad projects.
+"""Bill of Materials (BOM) processing tools for KiCad projects.
+
+Registers MCP tools for analyzing and exporting BOMs, plus helper
+functions for parsing CSV/XML/JSON BOM files.
 """
 
 import csv

--- a/kicad_mcp/tools/circuit_tools.py
+++ b/kicad_mcp/tools/circuit_tools.py
@@ -1,5 +1,7 @@
-"""
-Circuit creation tools for KiCad projects.
+"""Circuit creation tools for KiCad projects.
+
+Provides MCP tools and standalone functions for creating projects,
+adding components, wiring connections, and validating schematics.
 """
 
 import json
@@ -789,7 +791,11 @@ async def add_power_symbol(
 def _read_schematic_for_modification(schematic_file: str) -> dict[str, Any]:
     """Read a schematic file and determine if it can be modified by JSON operations.
 
-    Returns appropriate error if the file is in S-expression format.
+    Args:
+        schematic_file: Path to the schematic file.
+
+    Returns:
+        Dict with ``success`` bool and ``data`` (parsed JSON) or ``error`` message.
     """
     with open(schematic_file) as f:
         content = f.read().strip()
@@ -816,7 +822,13 @@ def _read_schematic_for_modification(schematic_file: str) -> dict[str, Any]:
 def _parse_sexpr_for_validation(content: str) -> dict[str, Any]:
     """Parse S-expression schematic content for validation purposes.
 
-    This is a simplified parser that extracts basic information needed for validation.
+    A simplified parser that extracts symbols and wires for validation.
+
+    Args:
+        content: Raw S-expression schematic content.
+
+    Returns:
+        Dict with ``symbol`` and ``wire`` lists.
     """
     result = {"symbol": [], "wire": []}
 
@@ -1025,8 +1037,11 @@ def get_kicad_cli_path() -> str | None:
 def register_circuit_tools(mcp: FastMCP) -> None:
     """Register circuit creation tools with the MCP server.
 
+    Registers ``create_new_project``, ``add_component``, ``create_wire_connection``,
+    ``add_power_symbol``, and ``validate_schematic`` tools.
+
     Args:
-        mcp: The FastMCP server instance
+        mcp: The FastMCP server instance.
     """
 
     @mcp.tool(name="create_new_project")

--- a/kicad_mcp/tools/drc_impl/__init__.py
+++ b/kicad_mcp/tools/drc_impl/__init__.py
@@ -1,3 +1,4 @@
-"""
-DRC implementations for different KiCad API approaches.
+"""DRC implementations for different KiCad API approaches.
+
+Currently provides CLI-based DRC via ``kicad-cli pcb drc``.
 """

--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -1,5 +1,6 @@
-"""
-Design Rule Check (DRC) implementation using KiCad command-line interface.
+"""Design Rule Check (DRC) implementation using KiCad command-line interface.
+
+Runs ``kicad-cli pcb drc`` and parses the JSON report.
 """
 
 import json

--- a/kicad_mcp/tools/drc_tools.py
+++ b/kicad_mcp/tools/drc_tools.py
@@ -1,5 +1,6 @@
-"""
-Design Rule Check (DRC) tools for KiCad PCB files.
+"""Design Rule Check (DRC) tools for KiCad PCB files.
+
+Registers MCP tools for running DRC checks and viewing DRC history.
 """
 
 import os

--- a/kicad_mcp/tools/export_tools.py
+++ b/kicad_mcp/tools/export_tools.py
@@ -1,5 +1,6 @@
-"""
-Export tools for KiCad projects.
+"""Export tools for KiCad projects.
+
+Registers MCP tools for generating PCB thumbnails via ``kicad-cli pcb export svg``.
 """
 
 import asyncio

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -1,5 +1,7 @@
-"""
-Netlist extraction and analysis tools for KiCad schematics.
+"""Netlist extraction and analysis tools for KiCad schematics.
+
+Registers MCP tools for extracting netlists, analyzing connections, and
+finding component connectivity.
 """
 
 import logging

--- a/kicad_mcp/tools/pattern_tools.py
+++ b/kicad_mcp/tools/pattern_tools.py
@@ -1,5 +1,7 @@
-"""
-Circuit pattern recognition tools for KiCad schematics.
+"""Circuit pattern recognition tools for KiCad schematics.
+
+Registers MCP tools that identify common circuit blocks (power supplies,
+amplifiers, filters, etc.) in schematics.
 """
 
 import os

--- a/kicad_mcp/tools/project_tools.py
+++ b/kicad_mcp/tools/project_tools.py
@@ -1,5 +1,6 @@
-"""
-Project management tools for KiCad.
+"""Project management tools for KiCad.
+
+Registers MCP tools for listing, inspecting, and opening KiCad projects.
 """
 
 import logging

--- a/kicad_mcp/tools/text_to_schematic.py
+++ b/kicad_mcp/tools/text_to_schematic.py
@@ -75,8 +75,9 @@ class TextToSchematicParser:
         "connector": ("Connector", "Conn_01x02"),
     }
 
-    def __init__(self):
-        self.circuits = []
+    def __init__(self) -> None:
+        """Initialize the parser."""
+        self.circuits: list[Circuit] = []
 
     def parse_yaml_circuit(self, yaml_text: str) -> Circuit:
         """Parse a YAML-format circuit description.
@@ -511,7 +512,11 @@ class TextToSchematicParser:
 
 
 def register_text_to_schematic_tools(mcp: FastMCP) -> None:
-    """Register text-to-schematic tools with the MCP server."""
+    """Register text-to-schematic tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
 
     @mcp.tool()
     async def create_circuit_from_text(

--- a/kicad_mcp/utils/__init__.py
+++ b/kicad_mcp/utils/__init__.py
@@ -1,3 +1,5 @@
-"""
-Utility functions for KiCad MCP Server.
+"""Utility functions for KiCad MCP Server.
+
+Provides file parsing, coordinate conversion, connectivity tracing,
+subprocess management, and other shared helpers.
 """

--- a/kicad_mcp/utils/connectivity.py
+++ b/kicad_mcp/utils/connectivity.py
@@ -14,6 +14,7 @@ class UnionFind:
     """Disjoint Set Union with path compression and union by rank."""
 
     def __init__(self) -> None:
+        """Initialize empty Union-Find structure."""
         self._parent: dict[int, int] = {}
         self._rank: dict[int, int] = {}
 
@@ -62,6 +63,11 @@ class ConnectivityEngine:
     """
 
     def __init__(self, tolerance: float = COORDINATE_TOLERANCE) -> None:
+        """Initialize the connectivity engine.
+
+        Args:
+            tolerance: Coordinate snapping tolerance in mm.
+        """
         self.tolerance = tolerance
         self._uf = UnionFind()
         self._point_to_id: dict[tuple[int, int], int] = {}
@@ -70,7 +76,15 @@ class ConnectivityEngine:
         self._label_points: list[tuple[str, str, int]] = []  # (text, label_type, point_id)
 
     def _get_point_id(self, x: float, y: float) -> int:
-        """Get or create a unique ID for a quantized point."""
+        """Get or create a unique ID for a quantized point.
+
+        Args:
+            x: X coordinate in mm.
+            y: Y coordinate in mm.
+
+        Returns:
+            Integer point ID for use in Union-Find.
+        """
         key = quantize_point(x, y, self.tolerance)
         if key not in self._point_to_id:
             pid = self._next_id

--- a/kicad_mcp/utils/coordinate_converter.py
+++ b/kicad_mcp/utils/coordinate_converter.py
@@ -13,8 +13,8 @@ KICAD_MILS_PER_MM = 39.37  # 1mm = 39.37 mils
 class CoordinateConverter:
     """Converts between ComponentLayoutManager coordinates and KiCad coordinates."""
 
-    def __init__(self):
-        """Initialize the coordinate converter."""
+    def __init__(self) -> None:
+        """Initialize the coordinate converter with A4 sheet dimensions."""
         # KiCad schematic coordinate origin (top-left in KiCad units)
         # A4 sheet dimensions in KiCad units
         self.sheet_width_kicad = 297.0 * KICAD_UNITS_PER_MM  # 29700 units

--- a/kicad_mcp/utils/env.py
+++ b/kicad_mcp/utils/env.py
@@ -1,5 +1,6 @@
-"""
-Environment variable handling for KiCad MCP Server.
+"""Environment variable handling for KiCad MCP Server.
+
+Loads ``.env`` files and provides helpers for reading list-valued env vars.
 """
 
 import logging
@@ -108,7 +109,7 @@ def find_env_file(filename: str = ".env") -> str | None:
     return None
 
 
-def get_env_list(env_var: str, default: str = "") -> list:
+def get_env_list(env_var: str, default: str = "") -> list[str]:
     """Get a list from a comma-separated environment variable.
 
     Args:

--- a/kicad_mcp/utils/file_utils.py
+++ b/kicad_mcp/utils/file_utils.py
@@ -1,5 +1,6 @@
-"""
-File handling utilities for KiCad MCP Server.
+"""File handling utilities for KiCad MCP Server.
+
+Provides helpers for discovering project-related files and loading project JSON.
 """
 
 import json

--- a/kicad_mcp/utils/kicad_api_detection.py
+++ b/kicad_mcp/utils/kicad_api_detection.py
@@ -1,5 +1,6 @@
-"""
-Utility functions for detecting and selecting available KiCad API approaches.
+"""Utility functions for detecting and selecting available KiCad API approaches.
+
+Checks for a working ``kicad-cli`` binary in PATH or common install locations.
 """
 
 import os

--- a/kicad_mcp/utils/kicad_utils.py
+++ b/kicad_mcp/utils/kicad_utils.py
@@ -1,5 +1,6 @@
-"""
-KiCad-specific utility functions.
+"""KiCad-specific utility functions.
+
+Provides project discovery, project-name extraction, and KiCad application launching.
 """
 
 import logging  # Import logging

--- a/kicad_mcp/utils/mock_renderer.py
+++ b/kicad_mcp/utils/mock_renderer.py
@@ -11,8 +11,8 @@ from typing import Any
 class MockSchematicRenderer:
     """Simple SVG renderer for KiCad schematics when CLI is not available."""
 
-    def __init__(self):
-        """Initialize the mock renderer."""
+    def __init__(self) -> None:
+        """Initialize the mock renderer with default canvas dimensions."""
         self.canvas_width = 800
         self.canvas_height = 600
         self.grid_size = 20
@@ -79,7 +79,15 @@ class MockSchematicRenderer:
         }
 
     def _get_component_type(self, lib_id: str, reference: str) -> str:
-        """Determine component type from library ID and reference."""
+        """Determine component type from library ID and reference.
+
+        Args:
+            lib_id: KiCad library identifier.
+            reference: Component reference designator.
+
+        Returns:
+            Component type string (e.g., "resistor", "capacitor").
+        """
         lib_id_lower = lib_id.lower()
         reference.lower()
 
@@ -183,7 +191,14 @@ class MockSchematicRenderer:
     def _render_component(
         self, svg_content: str, component: dict[str, Any], x: float, y: float
     ) -> None:
-        """Add component to SVG content."""
+        """Add component shape and labels to SVG content.
+
+        Args:
+            svg_content: SVG string being built (mutated in place via concatenation).
+            component: Parsed component dictionary.
+            x: Transformed X coordinate.
+            y: Transformed Y coordinate.
+        """
         comp_type = component["type"]
         reference = component["reference"]
         value = component["value"]
@@ -243,7 +258,14 @@ class MockSchematicRenderer:
     def _render_power_symbol(
         self, svg_content: str, power: dict[str, Any], x: float, y: float
     ) -> None:
-        """Add power symbol to SVG content."""
+        """Add power symbol shape to SVG content.
+
+        Args:
+            svg_content: SVG string being built.
+            power: Parsed power symbol dictionary.
+            x: Transformed X coordinate.
+            y: Transformed Y coordinate.
+        """
         value = power["value"]
         power["reference"]
 
@@ -299,7 +321,7 @@ class MockSchematicRenderer:
             return False
 
 
-def create_mock_schematic_screenshot(schematic_file: str, output_dir: str) -> str:
+def create_mock_schematic_screenshot(schematic_file: str, output_dir: str) -> str | None:
     """Create a mock screenshot of a schematic using the mock renderer.
 
     Args:

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -1,5 +1,7 @@
-"""
-KiCad schematic netlist extraction utilities.
+"""KiCad schematic netlist extraction utilities.
+
+Parses ``.kicad_sch`` and JSON schematic files to extract components,
+wires, labels, and net connectivity information.
 """
 
 from collections import defaultdict
@@ -51,7 +53,11 @@ class SchematicParser:
         self._load_schematic()
 
     def _load_schematic(self) -> None:
-        """Load the schematic file content."""
+        """Load the schematic file content into ``self.content``.
+
+        Raises:
+            FileNotFoundError: If the schematic file does not exist.
+        """
         if not os.path.exists(self.schematic_path):
             logger.error("Schematic file not found: %s", self.schematic_path)
             raise FileNotFoundError(f"Schematic file not found: {self.schematic_path}")
@@ -160,7 +166,7 @@ class SchematicParser:
         return matches
 
     def _extract_components(self) -> None:
-        """Extract component information from schematic."""
+        """Extract component information from schematic into ``self.components``."""
         logger.debug("Extracting components")
 
         # Extract all symbol expressions (components)
@@ -239,7 +245,14 @@ class SchematicParser:
             return {}
 
     def _extract_wires(self, content: str) -> list[dict[str, Any]]:
-        """Extract all wire expressions from the schematic content."""
+        """Extract all wire expressions from the schematic content.
+
+        Args:
+            content: Raw schematic file content.
+
+        Returns:
+            List of wire dicts with ``uuid``, ``start``, and ``end`` keys.
+        """
         wires = []
         # A more robust regex to capture wire data including nested structures
         wire_matches = re.finditer(r"\(\s*wire\s+((?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\)", content)
@@ -264,7 +277,14 @@ class SchematicParser:
         return wires
 
     def _extract_junctions(self, content: str) -> list[dict[str, Any]]:
-        """Extract all junction expressions from the schematic content."""
+        """Extract all junction expressions from the schematic content.
+
+        Args:
+            content: Raw schematic file content.
+
+        Returns:
+            List of junction dicts with ``x`` and ``y`` keys.
+        """
         junctions = []
         junction_matches = re.finditer(
             r"\(\s*junction\s+\(at\s+([\d\.-]+)\s+([\d\.-]+)\s*\)(?:.|\n)*?\)", content
@@ -276,7 +296,14 @@ class SchematicParser:
     def _extract_labels(
         self, content: str
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-        """Extract all label expressions from the schematic content."""
+        """Extract all label expressions from the schematic content.
+
+        Args:
+            content: Raw schematic file content.
+
+        Returns:
+            Tuple of (local_labels, global_labels, hierarchical_labels).
+        """
         labels = []
         global_labels = []
         hierarchical_labels = []
@@ -324,7 +351,7 @@ class SchematicParser:
         return labels, global_labels, hierarchical_labels
 
     def _extract_power_symbols(self) -> None:
-        """Extract power symbol information from schematic."""
+        """Extract power symbol information from schematic into ``self.power_symbols``."""
         logger.debug("Extracting power symbols")
 
         # Extract all power symbol expressions
@@ -350,7 +377,7 @@ class SchematicParser:
         logger.debug("Extracted %d power symbols", len(self.power_symbols))
 
     def _extract_no_connects(self) -> None:
-        """Extract no-connect information from schematic."""
+        """Extract no-connect information from schematic into ``self.no_connects``."""
         logger.debug("Extracting no-connects")
 
         # Extract all no-connect expressions
@@ -496,7 +523,11 @@ class SchematicParser:
         return resolved
 
     def _build_netlist(self) -> None:
-        """Build the netlist using wire connectivity tracing."""
+        """Build the netlist using wire connectivity tracing.
+
+        Populates ``self.nets`` and ``self.component_pins`` from parsed
+        wires, labels, and resolved pin positions.
+        """
         logger.debug("Building netlist from schematic data")
 
         engine = ConnectivityEngine()

--- a/kicad_mcp/utils/pattern_recognition.py
+++ b/kicad_mcp/utils/pattern_recognition.py
@@ -1,5 +1,7 @@
-"""
-Circuit pattern recognition functions for KiCad schematics.
+"""Circuit pattern recognition functions for KiCad schematics.
+
+Identifies common circuit blocks (power supplies, amplifiers, filters,
+oscillators, digital interfaces, sensors, microcontrollers) from netlist data.
 """
 
 import re

--- a/kicad_mcp/utils/pin_mapper.py
+++ b/kicad_mcp/utils/pin_mapper.py
@@ -184,8 +184,8 @@ class ComponentPinMapper:
         ],
     }
 
-    def __init__(self):
-        """Initialize the pin mapper."""
+    def __init__(self) -> None:
+        """Initialize the pin mapper with empty component and connection maps."""
         self.component_pins: dict[str, list[ComponentPin]] = {}
         self.pin_connections: dict[str, set[str]] = {}  # Track which pins are connected
 
@@ -230,11 +230,26 @@ class ComponentPinMapper:
         return component_pins
 
     def get_component_pins(self, component_ref: str) -> list[ComponentPin]:
-        """Get all pins for a component."""
+        """Get all pins for a component.
+
+        Args:
+            component_ref: Component reference designator.
+
+        Returns:
+            List of ComponentPin objects, empty if component not found.
+        """
         return self.component_pins.get(component_ref, [])
 
     def get_pin(self, component_ref: str, pin_number: str) -> ComponentPin | None:
-        """Get a specific pin from a component."""
+        """Get a specific pin from a component.
+
+        Args:
+            component_ref: Component reference designator.
+            pin_number: Pin number string.
+
+        Returns:
+            Matching ComponentPin or None if not found.
+        """
         pins = self.get_component_pins(component_ref)
         for pin in pins:
             if pin.pin_info.number == pin_number:
@@ -244,12 +259,28 @@ class ComponentPinMapper:
     def get_pin_connection_point(
         self, component_ref: str, pin_number: str
     ) -> tuple[float, float] | None:
-        """Get the connection point for a specific pin."""
+        """Get the wire connection point for a specific pin.
+
+        Args:
+            component_ref: Component reference designator.
+            pin_number: Pin number string.
+
+        Returns:
+            (x, y) tuple or None if pin not found.
+        """
         pin = self.get_pin(component_ref, pin_number)
         return pin.connection_point if pin else None
 
     def can_connect_pins(self, pin1: ComponentPin, pin2: ComponentPin) -> bool:
-        """Check if two pins can be electrically connected."""
+        """Check if two pins can be electrically connected.
+
+        Args:
+            pin1: First pin.
+            pin2: Second pin.
+
+        Returns:
+            True if a valid electrical connection is possible.
+        """
         # Power pins should connect to compatible pins
         if pin1.pin_info.pin_type == PinType.POWER:
             return pin2.pin_info.direction in [PinDirection.POWER_IN, PinDirection.PASSIVE]
@@ -322,7 +353,15 @@ class ComponentPinMapper:
         return True
 
     def get_connected_pins(self, component_ref: str, pin_number: str) -> list[str]:
-        """Get all pins connected to the specified pin."""
+        """Get all pins connected to the specified pin.
+
+        Args:
+            component_ref: Component reference designator.
+            pin_number: Pin number string.
+
+        Returns:
+            List of connected pin IDs in ``component.pin`` format.
+        """
         pin_id = f"{component_ref}.{pin_number}"
         return list(self.pin_connections.get(pin_id, set()))
 
@@ -453,7 +492,11 @@ class ComponentPinMapper:
         return routes
 
     def get_component_statistics(self) -> dict[str, int]:
-        """Get statistics about mapped components and pins."""
+        """Get statistics about mapped components and pins.
+
+        Returns:
+            Dict with ``total_components``, ``total_pins``, ``total_connections``.
+        """
         total_components = len(self.component_pins)
         total_pins = sum(len(pins) for pins in self.component_pins.values())
         total_connections = len(self.pin_connections)
@@ -464,7 +507,7 @@ class ComponentPinMapper:
             "total_connections": total_connections,
         }
 
-    def clear_mappings(self):
+    def clear_mappings(self) -> None:
         """Clear all component and pin mappings."""
         self.component_pins.clear()
         self.pin_connections.clear()
@@ -512,7 +555,7 @@ class ComponentPinMapper:
         return connections
 
     def _is_valid_connection_spec(self, conn: dict[str, Any]) -> bool:
-        """Validate a connection specification."""
+        """Validate a connection specification has required ``from`` and ``to`` fields."""
         required_fields = ["from", "to"]
         if not all(field in conn for field in required_fields):
             return False
@@ -532,7 +575,7 @@ class ComponentPinMapper:
     def _detect_power_connections(
         self, circuit_description: dict[str, Any]
     ) -> list[dict[str, str]]:
-        """Auto-detect power and ground connections."""
+        """Auto-detect power and ground connections from component types."""
         connections = []
 
         if "components" not in circuit_description:
@@ -600,7 +643,15 @@ class ComponentPinMapper:
         return connections
 
     def _get_power_pin(self, component_type: str, pin_type: str) -> str:
-        """Get the appropriate power pin for a component type."""
+        """Get the appropriate power pin number for a component type.
+
+        Args:
+            component_type: Component category (e.g., "ic", "battery").
+            pin_type: Pin role (e.g., "vcc", "gnd", "positive").
+
+        Returns:
+            Pin number string, or empty string if no mapping exists.
+        """
         power_pin_mappings = {
             "battery": {"positive": "1", "negative": "2"},
             "power_supply": {"positive": "1", "negative": "2"},
@@ -616,7 +667,10 @@ class ComponentPinMapper:
     def _detect_signal_connections(
         self, circuit_description: dict[str, Any]
     ) -> list[dict[str, str]]:
-        """Auto-detect signal chain connections based on component arrangement."""
+        """Auto-detect signal chain connections based on component arrangement.
+
+        Recognizes LED circuits and amplifier input/output chains.
+        """
         connections = []
 
         if "components" not in circuit_description:

--- a/kicad_mcp/utils/sexpr_handler.py
+++ b/kicad_mcp/utils/sexpr_handler.py
@@ -27,8 +27,8 @@ class SExpressionHandler:
     using the native sexpdata library and following KiCad's format specification.
     """
 
-    def __init__(self):
-        """Initialize the S-expression handler."""
+    def __init__(self) -> None:
+        """Initialize the S-expression handler with layout, pin, and routing managers."""
         self.layout_manager = ComponentLayoutManager()
         self.pin_mapper = ComponentPinMapper()
         self.wire_router = WireRouter(self.layout_manager.bounds)
@@ -173,7 +173,17 @@ class SExpressionHandler:
         power_symbols: list[dict[str, Any]],
         connections: list[dict[str, Any]],
     ) -> list[Any]:
-        """Build the complete schematic S-expression structure."""
+        """Build the complete schematic S-expression structure.
+
+        Args:
+            circuit_name: Title for the schematic title block.
+            components: Validated component dicts with positions.
+            power_symbols: Validated power symbol dicts with positions.
+            connections: Wire connection dicts.
+
+        Returns:
+            Nested list representing the full ``kicad_sch`` S-expression.
+        """
 
         # Generate a unique UUID for the sheet
         sheet_uuid = str(uuid.uuid4())
@@ -250,7 +260,17 @@ class SExpressionHandler:
         power_symbols: list[dict[str, Any]],
         wire_sexprs: list[list[Any]],
     ) -> list[Any]:
-        """Build schematic S-expression with pre-generated wire S-expressions."""
+        """Build schematic S-expression with pre-generated wire S-expressions.
+
+        Args:
+            circuit_name: Title for the schematic title block.
+            components: Validated component dicts with positions.
+            power_symbols: Validated power symbol dicts with positions.
+            wire_sexprs: Pre-routed wire S-expression lists.
+
+        Returns:
+            Nested list representing the full ``kicad_sch`` S-expression.
+        """
 
         # Generate a unique UUID for the sheet
         sheet_uuid = str(uuid.uuid4())
@@ -320,7 +340,14 @@ class SExpressionHandler:
         return schematic
 
     def _build_symbol_sexpr(self, component: dict[str, Any]) -> list[Any]:
-        """Build S-expression for a symbol (component or power symbol)."""
+        """Build S-expression for a symbol (component or power symbol).
+
+        Args:
+            component: Component dict with reference, value, position, etc.
+
+        Returns:
+            Nested list representing a ``symbol`` S-expression.
+        """
 
         # Extract component information
         lib_id = component.get("lib_id")
@@ -457,7 +484,7 @@ class SExpressionHandler:
         return wire_sexprs
 
     def _setup_routing_obstacles(self, components: list[dict[str, Any]]) -> None:
-        """Setup routing obstacles from component placements."""
+        """Register component bounding boxes as routing obstacles."""
         for component in components:
             if "position" not in component:
                 continue
@@ -652,7 +679,14 @@ class SExpressionHandler:
         return wire_expr
 
     def _parse_sexpr_to_dict(self, sexpr: Any) -> dict[str, Any]:
-        """Convert parsed S-expression to dictionary format."""
+        """Convert parsed S-expression to dictionary format.
+
+        Args:
+            sexpr: Parsed S-expression (nested lists from ``sexpdata``).
+
+        Returns:
+            Dictionary representation with ``type``, ``symbols``, ``wires``, etc.
+        """
         if not isinstance(sexpr, list) or len(sexpr) < 2:
             return {}
 
@@ -681,7 +715,14 @@ class SExpressionHandler:
         return result
 
     def _parse_symbol_sexpr(self, symbol_expr: list[Any]) -> dict[str, Any]:
-        """Parse a symbol S-expression into a dictionary."""
+        """Parse a symbol S-expression into a dictionary.
+
+        Args:
+            symbol_expr: Nested list for one ``symbol`` S-expression.
+
+        Returns:
+            Dict with ``lib_id``, ``reference``, ``value``, ``position``, etc.
+        """
         symbol = {}
 
         for item in symbol_expr[1:]:
@@ -713,7 +754,14 @@ class SExpressionHandler:
         return symbol
 
     def _parse_wire_sexpr(self, wire_expr: list[Any]) -> dict[str, Any]:
-        """Parse a wire S-expression into a dictionary."""
+        """Parse a wire S-expression into a dictionary.
+
+        Args:
+            wire_expr: Nested list for one ``wire`` S-expression.
+
+        Returns:
+            Dict with ``start``, ``end``, and ``uuid`` keys.
+        """
         wire = {}
 
         for item in wire_expr[1:]:
@@ -735,7 +783,15 @@ class SExpressionHandler:
         return wire
 
     def _format_sexpr(self, sexpr: list[Any], pretty_print: bool = True) -> str:
-        """Format S-expression as string."""
+        """Format S-expression as string.
+
+        Args:
+            sexpr: Nested list S-expression.
+            pretty_print: Whether to add indentation and newlines.
+
+        Returns:
+            Formatted S-expression string.
+        """
         formatted = sexpdata.dumps(sexpr)
 
         if pretty_print:
@@ -745,7 +801,14 @@ class SExpressionHandler:
         return formatted
 
     def _pretty_format_sexpr(self, sexpr_str: str) -> str:
-        """Apply basic pretty formatting to S-expression string."""
+        """Apply basic pretty formatting to S-expression string.
+
+        Args:
+            sexpr_str: Raw S-expression string from ``sexpdata.dumps``.
+
+        Returns:
+            Indented, line-broken S-expression string.
+        """
         lines = []
         indent_level = 0
         i = 0
@@ -787,7 +850,14 @@ class SExpressionHandler:
     def _validate_component_positions(
         self, components: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Validate and fix component positions using the layout manager."""
+        """Validate and fix component positions using the layout manager.
+
+        Args:
+            components: Component dicts, optionally with ``position`` keys.
+
+        Returns:
+            New list of component dicts with validated ``position`` tuples.
+        """
         validated_components = []
 
         for component in components:
@@ -821,7 +891,14 @@ class SExpressionHandler:
     def _validate_power_positions(
         self, power_symbols: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Validate and fix power symbol positions using the layout manager."""
+        """Validate and fix power symbol positions using the layout manager.
+
+        Args:
+            power_symbols: Power symbol dicts, optionally with ``position`` keys.
+
+        Returns:
+            New list of power symbol dicts with validated ``position`` tuples.
+        """
         validated_power_symbols = []
 
         for power_symbol in power_symbols:
@@ -870,7 +947,7 @@ class SExpressionHandler:
 
     def _map_component_pins(
         self, components: list[dict[str, Any]], power_symbols: list[dict[str, Any]]
-    ):
+    ) -> None:
         """Map all components and power symbols to the pin mapper."""
         for component in components:
             component_type = self._get_component_type(component)

--- a/kicad_mcp/utils/sexpr_service.py
+++ b/kicad_mcp/utils/sexpr_service.py
@@ -19,8 +19,8 @@ class SExpressionService:
     using the production-ready SExpressionHandler implementation.
     """
 
-    def __init__(self):
-        """Initialize the S-expression service."""
+    def __init__(self) -> None:
+        """Initialize the S-expression service with a backing handler."""
         self.logger = logging.getLogger(__name__)
         self.handler = SExpressionHandler()
 
@@ -80,7 +80,7 @@ def get_sexpr_service() -> SExpressionService:
     return _service_instance
 
 
-def reset_sexpr_service():
+def reset_sexpr_service() -> None:
     """Reset the global service instance (mainly for testing)."""
     global _service_instance
     _service_instance = None

--- a/kicad_mcp/utils/symbol_utils.py
+++ b/kicad_mcp/utils/symbol_utils.py
@@ -1,5 +1,6 @@
-"""
-Symbol library utility functions for KiCad circuit creation.
+"""Symbol library utility functions for KiCad circuit creation.
+
+Discovers, parses, and searches KiCad symbol libraries on the local filesystem.
 """
 
 import glob
@@ -12,9 +13,10 @@ from kicad_mcp.config import KICAD_APP_PATH, KICAD_USER_DIR, system
 class SymbolLibraryManager:
     """Manager class for KiCad symbol libraries and symbol operations."""
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize the manager and discover library paths on the current platform."""
         self.library_paths = self._discover_library_paths()
-        self.symbol_cache = {}
+        self.symbol_cache: dict[str, Any] = {}
 
     def _discover_library_paths(self) -> list[str]:
         """Discover KiCad symbol library paths based on the operating system.

--- a/kicad_mcp/utils/temp_dir_manager.py
+++ b/kicad_mcp/utils/temp_dir_manager.py
@@ -1,5 +1,6 @@
-"""
-Utility for managing temporary directories.
+"""Utility for managing temporary directories.
+
+Tracks temporary directories created during MCP operations for cleanup on shutdown.
 """
 
 # List of temporary directories to clean up

--- a/kicad_mcp/utils/visual_testing.py
+++ b/kicad_mcp/utils/visual_testing.py
@@ -12,11 +12,11 @@ from typing import Any
 class VisualTestUtils:
     """Utilities for visual testing and screenshot management."""
 
-    def __init__(self, output_dir: str = "tests/visual_output"):
+    def __init__(self, output_dir: str = "tests/visual_output") -> None:
         """Initialize visual test utilities.
 
         Args:
-            output_dir: Directory to store visual test outputs
+            output_dir: Directory to store visual test outputs.
         """
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)

--- a/kicad_mcp/utils/wire_router.py
+++ b/kicad_mcp/utils/wire_router.py
@@ -111,8 +111,12 @@ class WireRouter:
     - Wire priority handling
     """
 
-    def __init__(self, bounds: SchematicBounds):
-        """Initialize the wire router."""
+    def __init__(self, bounds: SchematicBounds) -> None:
+        """Initialize the wire router.
+
+        Args:
+            bounds: Schematic boundary constraints for routing.
+        """
         self.bounds = bounds
         self.obstacles: list[RoutingObstacle] = []
         self.routes: list[WireRoute] = []
@@ -316,13 +320,20 @@ class WireRouter:
         return detour_segments
 
     def snap_to_grid(self, point: tuple[float, float]) -> tuple[float, float]:
-        """Snap a point to the routing grid."""
+        """Snap a point to the routing grid.
+
+        Args:
+            point: (x, y) coordinate tuple.
+
+        Returns:
+            Grid-aligned (x, y) tuple.
+        """
         x, y = point
         grid = self.grid_spacing
         return (round(x / grid) * grid, round(y / grid) * grid)
 
     def optimize_routes(self) -> None:
-        """Optimize all routes for better layout and shorter paths."""
+        """Optimize all routes by priority ordering and segment merging."""
         # Sort routes by priority (higher priority routes get better paths)
         self.routes.sort(key=lambda route: route.priority, reverse=True)
 


### PR DESCRIPTION
## Summary

Completes documentation task started in PR #32. Adds concise Google-style docstrings and type hints across 42 files:

- `kicad_mcp/utils/` (16 files) — module docstrings, Args/Returns on private methods, `__init__ -> None` annotations
- `kicad_mcp/tools/` (11 files) — describe MCP tools each module registers
- `kicad_mcp/resources/` (6 files) — describe `kicad://` URI patterns registered
- `kicad_mcp/prompts/` (5 files) — describe prompt categories provided

Closes #25

## Test plan

- [x] All 412 tests pass
- [x] Pre-commit hooks pass
- [x] No verbose non-Google-style sections (Time Complexity, trivial Raises)

🤖 Generated with [Claude Code](https://claude.com/claude-code)