### PR TITLE
refactor: narrow bare except Exception clauses

### DIFF
--- a/kicad_mcp/context.py
+++ b/kicad_mcp/context.py
@@ -88,7 +88,7 @@ async def kicad_lifespan(
             try:
                 logging.info(f"Removing temporary directory: {temp_dir}")
                 shutil.rmtree(temp_dir, ignore_errors=True)
-            except Exception as e:
+            except OSError as e:
                 logging.error(f"Error cleaning up temporary directory {temp_dir}: {str(e)}")
 
         logging.info("KiCad MCP server shutdown complete")

--- a/kicad_mcp/resources/bom_resources.py
+++ b/kicad_mcp/resources/bom_resources.py
@@ -162,7 +162,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
 
                 report += "\n---\n\n"
 
-            except Exception as e:
+            except (OSError, ValueError, KeyError) as e:
                 logger.error("Error processing BOM file %s: %s", file_path, e)
                 report += f"## {file_type}\n\nError processing BOM file: {str(e)}\n\n"
 
@@ -226,7 +226,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
             df = pd.DataFrame(bom_data)
             return df.to_csv(index=False)
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error generating CSV from BOM file: %s", e)
             return f"Error generating CSV from BOM file: {str(e)}"
 
@@ -270,7 +270,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
                         try:
                             result["bom_files"][file_type] = json.load(f)
                             continue
-                        except Exception:
+                        except (json.JSONDecodeError, ValueError):
                             # If JSON parsing fails, fall back to regular parsing
                             pass
 
@@ -288,6 +288,6 @@ def register_bom_resources(mcp: FastMCP) -> None:
 
             return json.dumps(result, indent=2, default=str)
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error generating JSON from BOM file: %s", e)
             return json.dumps({"error": str(e)}, indent=2)

--- a/kicad_mcp/resources/files.py
+++ b/kicad_mcp/resources/files.py
@@ -45,5 +45,5 @@ def register_file_resources(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except OSError as e:
             return f"Error reading schematic file: {str(e)}"

--- a/kicad_mcp/resources/netlist_resources.py
+++ b/kicad_mcp/resources/netlist_resources.py
@@ -125,7 +125,7 @@ def register_netlist_resources(mcp: FastMCP) -> None:
 
             return report
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"# Netlist Extraction Error\n\nError: {str(e)}"
 
     @mcp.resource("kicad://project_netlist/{project_path}")
@@ -156,7 +156,7 @@ def register_netlist_resources(mcp: FastMCP) -> None:
             # Get the netlist resource for this schematic
             return get_netlist_resource(schematic_path)  # ty: ignore[call-non-callable]
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"# Netlist Extraction Error\n\nError: {str(e)}"
 
     @mcp.resource("kicad://component/{schematic_path}/{component_ref}")
@@ -265,5 +265,5 @@ def register_netlist_resources(mcp: FastMCP) -> None:
 
             return report
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"# Component Analysis Error\n\nError: {str(e)}"

--- a/kicad_mcp/resources/pattern_resources.py
+++ b/kicad_mcp/resources/pattern_resources.py
@@ -270,7 +270,7 @@ def register_pattern_resources(mcp: FastMCP) -> None:
 
             return report
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"# Circuit Pattern Analysis Error\n\nError: {str(e)}"
 
     @mcp.resource("kicad://patterns/project/{project_path}")
@@ -298,5 +298,5 @@ def register_pattern_resources(mcp: FastMCP) -> None:
             # Use the existing resource handler to generate the report
             return get_circuit_patterns_resource(schematic_path)  # ty: ignore[call-non-callable]
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"# Circuit Pattern Analysis Error\n\nError: {str(e)}"

--- a/kicad_mcp/resources/projects.py
+++ b/kicad_mcp/resources/projects.py
@@ -49,5 +49,5 @@ def register_project_resources(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             return f"Error reading project file: {str(e)}"

--- a/kicad_mcp/server.py
+++ b/kicad_mcp/server.py
@@ -87,7 +87,7 @@ def run_cleanup_handlers() -> None:
         try:
             handler()
             logging.info(f"Cleanup handler {handler.__name__} completed successfully")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — cleanup handlers must not propagate
             logging.error(f"Error in cleanup handler {handler.__name__}: {str(e)}", exc_info=True)
 
 
@@ -108,7 +108,7 @@ def shutdown_server() -> None:
             logging.info("Shutting down KiCad MCP server")
             _server_instance = None
             logging.info("KiCad MCP server shutdown complete")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — shutdown must not propagate
             logging.error(f"Error shutting down server: {str(e)}", exc_info=True)
 
 
@@ -236,7 +236,7 @@ def create_server() -> FastMCP:
                 if os.path.exists(temp_dir):
                     shutil.rmtree(temp_dir, ignore_errors=True)
                     logging.info(f"Removed temporary directory: {temp_dir}")
-            except Exception as e:
+            except OSError as e:
                 logging.error(f"Error cleaning up temporary directory {temp_dir}: {str(e)}")
 
     add_cleanup_handler(cleanup_temp_dirs)
@@ -307,7 +307,7 @@ def cleanup_handler() -> None:
     try:
         cleanup_temp_dirs()
         run_cleanup_handlers()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — cleanup must not propagate
         logger.error(f"Error during cleanup: {e}")
 
 
@@ -338,7 +338,7 @@ def cleanup_temp_dirs() -> None:
                 if os.path.exists(temp_dir):
                     shutil.rmtree(temp_dir, ignore_errors=True)
                     logger.info(f"Removed temporary directory: {temp_dir}")
-            except Exception as e:
+            except OSError as e:
                 logger.error(f"Error cleaning up temporary directory {temp_dir}: {str(e)}")
     except ImportError:
         # temp_dir_manager may not be available in all contexts
@@ -381,6 +381,6 @@ async def main() -> None:
     except KeyboardInterrupt:
         logger.info("Received keyboard interrupt, graceful shutdown initiated")
         cleanup_handler()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — top-level entry point ensures cleanup
         logger.error(f"Server startup error: {e}")
         cleanup_handler()

--- a/kicad_mcp/tools/analysis_tools.py
+++ b/kicad_mcp/tools/analysis_tools.py
@@ -65,7 +65,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
                 json.load(f)
         except json.JSONDecodeError:
             issues.append("Invalid project file format (JSON parsing error)")
-        except Exception as e:
+        except OSError as e:
             issues.append(f"Error reading project file: {str(e)}")
 
         return {

--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -109,7 +109,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
                 logger.info("Successfully analyzed BOM file: %s", file_path)
 
-            except Exception as e:
+            except (OSError, ValueError, KeyError) as e:
                 logger.error("Error analyzing BOM file %s: %s", file_path, e, exc_info=True)
                 results["bom_files"][file_type] = {"path": file_path, "error": str(e)}
 
@@ -209,7 +209,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
             export_result = await export_bom_with_cli(
                 schematic_file, project_dir, project_name, ctx
             )
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Error exporting BOM with CLI: %s", e, exc_info=True)
             await ctx.info(f"Error using command-line tools: {str(e)}")
             export_result = {"success": False, "error": str(e)}
@@ -340,11 +340,11 @@ def parse_bom_file(file_path: str) -> tuple[list[dict[str, Any]], dict[str, Any]
 
                     for row in reader:
                         components.append(dict(row))
-            except Exception:
+            except (OSError, csv.Error, UnicodeDecodeError):
                 logger.warning("Failed to parse unknown file format: %s", file_path)
                 return [], {"detected_format": "unsupported"}
 
-    except Exception as e:
+    except (OSError, ValueError, csv.Error, json.JSONDecodeError) as e:
         logger.error("Error parsing BOM file: %s", e, exc_info=True)
         return [], {"error": str(e)}
 
@@ -555,7 +555,7 @@ def analyze_bom_data(
 
                     if "currency" not in results:
                         results["currency"] = "USD"  # Default
-            except Exception:
+            except (ValueError, TypeError, KeyError):
                 logger.warning("Failed to parse cost data")
 
         # Add extra insights
@@ -565,7 +565,7 @@ def analyze_bom_data(
             most_common = value_counts.head(5).to_dict()
             results["most_common_values"] = {str(k): int(v) for k, v in most_common.items()}
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError) as e:
         logger.error("Error analyzing BOM data: %s", e, exc_info=True)
         # Fallback to basic analysis
         results["unique_component_count"] = len(components)
@@ -661,7 +661,7 @@ async def export_bom_with_cli(
             "schematic_file": schematic_file,
         }
 
-    except Exception as e:
+    except OSError as e:
         logger.error("Error exporting BOM: %s", e, exc_info=True)
         return {
             "success": False,

--- a/kicad_mcp/tools/circuit_tools.py
+++ b/kicad_mcp/tools/circuit_tools.py
@@ -269,7 +269,7 @@ async def create_new_project(
                 await ctx.info(
                     "⚠ Visualization tools not available - proceeding without visual feedback"
                 )
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 await ctx.info(f"⚠ Screenshot capture failed: {str(e)}")
 
             await ctx.report_progress(100, 100)
@@ -284,7 +284,7 @@ async def create_new_project(
             "project_name": project_name,
         }
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         error_msg = f"Error creating project '{project_name}' at '{project_path}': {str(e)}"
         if ctx:
             await ctx.info(error_msg)
@@ -453,7 +453,7 @@ async def add_component(
                     )
             except ImportError:
                 await ctx.info("⚠ Visualization tools not available")
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 await ctx.info(f"⚠ Screenshot capture failed: {str(e)}")
 
             await ctx.report_progress(100, 100)
@@ -471,7 +471,7 @@ async def add_component(
             },
         }
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as e:
         error_msg = f"Error adding component '{component_reference}' ({symbol_library}:{symbol_name}) to '{project_path}': {str(e)}"
         if ctx:
             await ctx.info(error_msg)
@@ -618,7 +618,7 @@ async def create_wire_connection(
                     )
             except ImportError:
                 await ctx.info("⚠ Visualization tools not available")
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 await ctx.info(f"⚠ Screenshot capture failed: {str(e)}")
 
             await ctx.report_progress(100, 100)
@@ -631,7 +631,7 @@ async def create_wire_connection(
             "wire_uuid": wire_entry["uuid"],
         }
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as e:
         if ctx:
             await ctx.info(f"Error creating wire: {str(e)}")
         return {"success": False, "error": str(e)}
@@ -776,7 +776,7 @@ async def add_power_symbol(
                     )
             except ImportError:
                 await ctx.info("⚠ Visualization tools not available")
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 await ctx.info(f"⚠ Screenshot capture failed: {str(e)}")
 
             await ctx.report_progress(100, 100)
@@ -794,7 +794,7 @@ async def add_power_symbol(
 
         return result
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as e:
         if ctx:
             await ctx.info(f"Error adding power symbol: {str(e)}")
         return {"success": False, "error": str(e)}
@@ -975,7 +975,7 @@ async def validate_schematic(project_path: str, ctx: Context | None = None) -> d
 
         return validation_results
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as e:
         if ctx:
             await ctx.info(f"Error validating schematic: {str(e)}")
         return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/drc_impl/cli_drc.py
+++ b/kicad_mcp/tools/drc_impl/cli_drc.py
@@ -117,7 +117,7 @@ async def run_drc_via_cli(pcb_file: str, ctx: Context | None = None) -> dict[str
                 await ctx.report_progress(90, 100)
             return results
 
-    except Exception as e:
+    except (OSError, json.JSONDecodeError, KeyError, SecureSubprocessError, KiCadCLIError) as e:
         logger.error("Error in CLI DRC: %s", e, exc_info=True)
         results["error"] = f"Error in CLI DRC: {str(e)}"
         return results

--- a/kicad_mcp/tools/export_tools.py
+++ b/kicad_mcp/tools/export_tools.py
@@ -89,7 +89,7 @@ def register_export_tools(mcp: FastMCP) -> None:
                     logger.warning("generate_thumbnail_with_cli returned None")
                     await ctx.info("Failed to generate thumbnail using kicad-cli.")
                     return None
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 logger.error("Error calling generate_thumbnail_with_cli: %s", e, exc_info=True)
                 await ctx.info(f"Error generating thumbnail with kicad-cli: {str(e)}")
                 return None
@@ -97,7 +97,7 @@ def register_export_tools(mcp: FastMCP) -> None:
         except asyncio.CancelledError:
             logger.info("Thumbnail generation cancelled")
             raise  # Re-raise to let MCP know the task was cancelled
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Unexpected error in thumbnail generation: %s", e)
             await ctx.info(f"Error: {str(e)}")
             return None
@@ -214,7 +214,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
             logger.error("Secure subprocess error: %s", e)
             await ctx.info(f"KiCad CLI command failed: {e}")
             return None
-        except Exception as e:
+        except OSError as e:
             logger.error("Error running CLI command: %s", e, exc_info=True)
             await ctx.info(f"Error running KiCad CLI: {str(e)}")
             return None
@@ -222,7 +222,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
     except asyncio.CancelledError:
         logger.info("CLI thumbnail generation cancelled")
         raise
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error("Unexpected error in CLI thumbnail generation: %s", e)
         await ctx.info(f"Unexpected error: {str(e)}")
         return None

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -90,7 +90,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error extracting netlist: %s", e, exc_info=True)
             await ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -144,7 +144,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error extracting project netlist: %s", e, exc_info=True)
             await ctx.info(f"Error extracting project netlist: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -254,7 +254,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error analyzing connections: %s", e, exc_info=True)
             await ctx.info(f"Error analyzing connections: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -413,7 +413,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error("Error finding component connections: %s", e, exc_info=True)
             await ctx.info(f"Error finding component connections: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/pattern_tools.py
+++ b/kicad_mcp/tools/pattern_tools.py
@@ -141,7 +141,7 @@ def register_pattern_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             await ctx.info(f"Error identifying circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}
 
@@ -183,6 +183,6 @@ def register_pattern_tools(mcp: FastMCP) -> None:
 
             return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             await ctx.info(f"Error analyzing project circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/text_to_schematic.py
+++ b/kicad_mcp/tools/text_to_schematic.py
@@ -174,7 +174,7 @@ class TextToSchematicParser:
                 connections=connections,
             )
 
-        except Exception as e:
+        except (yaml.YAMLError, ValueError, KeyError, TypeError) as e:
             raise ValueError(f"Error parsing YAML circuit: {str(e)}") from e
 
     def parse_simple_text(self, text: str) -> Circuit:
@@ -285,7 +285,7 @@ class TextToSchematicParser:
                 symbol_name=symbol_name,
             )
 
-        except Exception as e:
+        except (ValueError, IndexError) as e:
             logger.error("Error parsing component '%s': %s", comp_desc, e)
             return None
 
@@ -321,7 +321,7 @@ class TextToSchematicParser:
                 symbol_name=symbol_name,
             )
 
-        except Exception as e:
+        except (ValueError, TypeError, KeyError) as e:
             logger.error("Error parsing structured component %s: %s", comp_data, e)
             return None
 
@@ -376,7 +376,7 @@ class TextToSchematicParser:
                 symbol_name=symbol_name,
             )
 
-        except Exception:
+        except (ValueError, IndexError):
             return None
 
     def _parse_power_symbol(self, power_desc: str) -> PowerSymbol | None:
@@ -395,7 +395,7 @@ class TextToSchematicParser:
 
             return PowerSymbol(reference=ref, power_type=power_type, position=position)
 
-        except Exception:
+        except (ValueError, IndexError):
             return None
 
     def _parse_structured_power(self, power_data: dict) -> PowerSymbol | None:
@@ -411,7 +411,7 @@ class TextToSchematicParser:
             else:
                 position = (0.0, 0.0)
             return PowerSymbol(reference=net, power_type=power_type, position=position)
-        except Exception:
+        except (ValueError, TypeError, KeyError):
             return None
 
     def _parse_power_symbol_simple(self, line: str) -> PowerSymbol | None:
@@ -447,7 +447,7 @@ class TextToSchematicParser:
 
             return PowerSymbol(reference=ref, power_type=power_type, position=position)
 
-        except Exception:
+        except (ValueError, IndexError):
             return None
 
     def _parse_connection(self, conn_desc: Any) -> Connection | None:
@@ -489,7 +489,7 @@ class TextToSchematicParser:
                 end_pin=end_pin,
             )
 
-        except Exception:
+        except (ValueError, IndexError, TypeError):
             return None
 
     @staticmethod
@@ -593,7 +593,7 @@ def register_text_to_schematic_tools(mcp: FastMCP) -> None:
                             f"Failed to add {component.reference}: {result.get('error', 'Unknown error')}"
                         )
 
-                except Exception as e:
+                except (OSError, ValueError, KeyError) as e:
                     results["errors"].append(
                         f"Error adding component {component.reference}: {str(e)}"
                     )
@@ -620,7 +620,7 @@ def register_text_to_schematic_tools(mcp: FastMCP) -> None:
                             f"Failed to add power symbol {power_symbol.power_type}: {result.get('error', 'Unknown error')}"
                         )
 
-                except Exception as e:
+                except (OSError, ValueError, KeyError) as e:
                     results["errors"].append(
                         f"Error adding power symbol {power_symbol.power_type}: {str(e)}"
                     )
@@ -637,7 +637,7 @@ def register_text_to_schematic_tools(mcp: FastMCP) -> None:
                     results["connections_created"].append(
                         f"{connection.start_component} -> {connection.end_component}"
                     )
-                except Exception as e:
+                except (ValueError, AttributeError) as e:
                     results["errors"].append(f"Error creating connection: {str(e)}")
 
             if ctx:
@@ -648,7 +648,7 @@ def register_text_to_schematic_tools(mcp: FastMCP) -> None:
 
             return results
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError, yaml.YAMLError) as e:
             if ctx:
                 await ctx.info(f"Error creating circuit: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -714,7 +714,7 @@ def register_text_to_schematic_tools(mcp: FastMCP) -> None:
 
             return validation_results
 
-        except Exception as e:
+        except (ValueError, yaml.YAMLError) as e:
             if ctx:
                 await ctx.info(f"Validation error: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -1080,7 +1080,7 @@ circuit "I2C Sensor Interface":
                 result["output_format"] = "JSON"
                 return result
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError, yaml.YAMLError) as e:
             if ctx:
                 await ctx.info(f"Error creating native KiCad schematic: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/validation_tools.py
+++ b/kicad_mcp/tools/validation_tools.py
@@ -110,7 +110,7 @@ async def validate_project_boundaries(
 
         return result
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         error_msg = f"Error validating project boundaries: {str(e)}"
         if ctx:
             await ctx.info(error_msg)
@@ -173,7 +173,7 @@ async def generate_validation_report(
 
         return {"success": True, "report_path": output_path, "summary": report_data["summary"]}
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         error_msg = f"Error generating validation report: {str(e)}"
         if ctx:
             await ctx.info(error_msg)

--- a/kicad_mcp/tools/visualization_tools.py
+++ b/kicad_mcp/tools/visualization_tools.py
@@ -65,7 +65,7 @@ def register_visualization_tools(mcp: FastMCP) -> None:
             else:
                 return {"success": False, "error": svg_result["error"]}
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             error_msg = f"Error exporting schematic to SVG: {str(e)}"
             await ctx.info(error_msg)
             return {"success": False, "error": error_msg}
@@ -99,7 +99,7 @@ def register_visualization_tools(mcp: FastMCP) -> None:
             else:
                 return {"success": False, "error": conversion_result["error"]}
 
-        except Exception as e:
+        except (OSError, ValueError, ImportError) as e:
             error_msg = f"Error converting SVG to PNG: {str(e)}"
             await ctx.info(error_msg)
             return {"success": False, "error": error_msg}
@@ -142,7 +142,7 @@ def register_visualization_tools(mcp: FastMCP) -> None:
                 await ctx.info("PNG file not found after conversion")
                 return None
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             error_msg = f"Error capturing schematic screenshot: {str(e)}"
             await ctx.info(error_msg)
             return None
@@ -182,7 +182,7 @@ def register_visualization_tools(mcp: FastMCP) -> None:
             else:
                 return {"success": False, "error": comparison_result["error"]}
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             error_msg = f"Error creating visual comparison: {str(e)}"
             await ctx.info(error_msg)
             return {"success": False, "error": error_msg}
@@ -268,7 +268,7 @@ async def export_schematic_to_svg(
 
     except (SecureSubprocessError, KiCadCLIError) as e:
         return {"success": False, "error": f"kicad-cli export failed: {e}"}
-    except Exception as e:
+    except (OSError, ValueError) as e:
         return {"success": False, "error": f"Unexpected error during SVG export: {str(e)}"}
 
 
@@ -314,7 +314,7 @@ async def convert_svg_to_png_file(svg_path: str, png_path: str, ctx: Context) ->
         else:
             return {"success": False, "error": "PNG file not created"}
 
-    except Exception as e:
+    except (OSError, ValueError, ImportError) as e:
         return {"success": False, "error": f"SVG to PNG conversion failed: {str(e)}"}
 
 
@@ -373,7 +373,7 @@ async def create_side_by_side_comparison(
         draw = ImageDraw.Draw(comparison)
         try:
             font = ImageFont.truetype("Arial", 24)
-        except Exception:
+        except (OSError, ImportError):
             font = ImageFont.load_default()
 
         before_label = f"Before: {os.path.basename(before_path)}"
@@ -399,7 +399,7 @@ async def create_side_by_side_comparison(
             "after_project": after_path,
         }
 
-    except Exception as e:
+    except (OSError, ValueError, ImportError) as e:
         return {"success": False, "error": f"Failed to create comparison image: {str(e)}"}
 
 
@@ -441,5 +441,5 @@ async def export_schematic_to_svg_mock(
         else:
             return {"success": False, "error": "Mock renderer failed to generate SVG"}
 
-    except Exception as e:
+    except (OSError, ValueError, ImportError) as e:
         return {"success": False, "error": f"Mock renderer error: {str(e)}"}

--- a/kicad_mcp/utils/env.py
+++ b/kicad_mcp/utils/env.py
@@ -74,9 +74,9 @@ def load_dotenv(env_file: str = ".env") -> dict[str, str]:
                     logging.warning(f"Skipping line {line_num} (no '=' found): {line}")
             logging.info(f"Finished processing {env_path}")
 
-    except Exception:
+    except (OSError, ValueError) as exc:
         # Use logging.exception to include traceback
-        logging.exception(f"Error loading .env file '{env_path}'")
+        logging.exception(f"Error loading .env file '{env_path}': {exc}")
 
     logging.info(f"load_dotenv returning keys: {list(env_vars.keys())}")
     return env_vars

--- a/kicad_mcp/utils/file_utils.py
+++ b/kicad_mcp/utils/file_utils.py
@@ -68,5 +68,5 @@ def load_project_json(project_path: str) -> dict[str, Any] | None:
     try:
         with open(project_path) as f:
             return json.load(f)
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return None

--- a/kicad_mcp/utils/kicad_api_detection.py
+++ b/kicad_mcp/utils/kicad_api_detection.py
@@ -72,6 +72,6 @@ def check_for_cli_api() -> bool:
         logger.info("KiCad CLI API is not available")
         return False
 
-    except Exception as e:
+    except OSError as e:
         logger.error("Error checking for KiCad CLI API: %s", e)
         return False

--- a/kicad_mcp/utils/kicad_utils.py
+++ b/kicad_mcp/utils/kicad_utils.py
@@ -211,5 +211,5 @@ def open_kicad_project(project_path: str) -> dict[str, Any]:
         return {"success": False, "error": f"Invalid project path: {e}"}
     except SecureSubprocessError as e:
         return {"success": False, "error": f"Failed to open project: {e}"}
-    except Exception as e:
+    except OSError as e:
         return {"success": False, "error": f"Unexpected error: {e}"}

--- a/kicad_mcp/utils/mock_renderer.py
+++ b/kicad_mcp/utils/mock_renderer.py
@@ -319,7 +319,7 @@ class MockSchematicRenderer:
 
             return True
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Error rendering schematic: %s", e)
             return False
 

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -66,7 +66,7 @@ class SchematicParser:
             with open(self.schematic_path) as f:
                 self.content = f.read()
                 logger.debug("Successfully loaded schematic: %s", self.schematic_path)
-        except Exception as e:
+        except OSError as e:
             logger.error("Error reading schematic file: %s", e, exc_info=True)
             raise
 
@@ -238,7 +238,7 @@ class SchematicParser:
                         component["pins"].append({"num": pin_num, "uuid": pin_uuid_item[1]})
 
             return component
-        except Exception as e:
+        except (ValueError, TypeError, IndexError, AttributeError) as e:
             logger.warning(
                 "Failed to parse component expression: %s\nExpression:\n%s", e, symbol_expr
             )
@@ -627,7 +627,7 @@ def extract_netlist(schematic_path: str) -> dict[str, Any]:
         logger.info("Using S-expression parser for: %s", schematic_path)
         parser = SchematicParser(schematic_path)
         return parser.parse()
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         logger.error("Error extracting netlist: %s", e, exc_info=True)
         return {"error": str(e), "components": {}, "nets": {}, "component_count": 0, "net_count": 0}
 

--- a/kicad_mcp/utils/sexpr_handler.py
+++ b/kicad_mcp/utils/sexpr_handler.py
@@ -48,7 +48,14 @@ class SExpressionHandler:
         try:
             parsed = sexpdata.loads(content)
             return self._parse_sexpr_to_dict(parsed)
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            IndexError,
+            sexpdata.ExpectClosingBracket,
+            sexpdata.ExpectNothing,
+            sexpdata.ExpectSExp,
+        ) as e:
             raise ValueError(f"Failed to parse S-expression content: {e}") from e
 
     def generate_schematic(

--- a/kicad_mcp/utils/symbol_utils.py
+++ b/kicad_mcp/utils/symbol_utils.py
@@ -77,7 +77,7 @@ class SymbolLibraryManager:
                 try:
                     symbol_count = self._count_symbols_in_library(symbol_file)
                     lib_info["symbol_count"] = symbol_count
-                except Exception:
+                except OSError:
                     lib_info["symbol_count"] = "unknown"
 
                 libraries.append(lib_info)
@@ -98,7 +98,7 @@ class SymbolLibraryManager:
                 content = f.read()
                 # Count symbol definitions (simplified)
                 return content.count('(symbol "')
-        except Exception:
+        except OSError:
             return 0
 
     def search_symbols(
@@ -127,7 +127,7 @@ class SymbolLibraryManager:
                         symbol["library"] = library["name"]
                         symbol["library_path"] = library["path"]
                         results.append(symbol)
-            except Exception:
+            except (OSError, ValueError):
                 # Skip libraries that can't be parsed
                 continue
 
@@ -168,7 +168,7 @@ class SymbolLibraryManager:
 
                 symbols.append(symbol_info)
 
-        except Exception:
+        except (OSError, ValueError):
             # Return empty list if parsing fails
             pass
 
@@ -203,7 +203,7 @@ class SymbolLibraryManager:
                 }
                 pins.append(pin_info)
 
-        except Exception:
+        except (ValueError, AttributeError):
             pass
 
         return pins
@@ -230,7 +230,7 @@ class SymbolLibraryManager:
                 prop_value = match.group(2)
                 properties[prop_name] = prop_value
 
-        except Exception:
+        except (ValueError, AttributeError):
             pass
 
         return properties
@@ -265,7 +265,7 @@ class SymbolLibraryManager:
                     symbol["library"] = library_name
                     symbol["library_path"] = target_library["path"]
                     return symbol
-        except Exception:
+        except (OSError, ValueError):
             pass
 
         return None
@@ -459,7 +459,7 @@ def validate_symbol_library_reference(library_name: str, symbol_name: str) -> bo
         manager = SymbolLibraryManager()
         symbol_info = manager.get_symbol_info(library_name, symbol_name)
         return symbol_info is not None
-    except Exception:
+    except (OSError, ValueError):
         return False
 
 
@@ -479,7 +479,7 @@ def get_symbol_pin_count(library_name: str, symbol_name: str) -> int:
 
         if symbol_info and "pins" in symbol_info:
             return len(symbol_info["pins"])
-    except Exception:
+    except (OSError, ValueError):
         pass
 
     return 0

--- a/kicad_mcp/utils/visual_testing.py
+++ b/kicad_mcp/utils/visual_testing.py
@@ -76,7 +76,7 @@ class VisualTestUtils:
 
             return png_file
 
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error("Error capturing screenshot: %s", e)
             return None
 
@@ -107,7 +107,7 @@ class VisualTestUtils:
                 try:
                     file_path.unlink()
                     cleaned_count += 1
-                except Exception as e:
+                except OSError as e:
                     logger.warning("Error cleaning up %s: %s", file_path, e)
 
         # Also clean up empty directories
@@ -115,7 +115,7 @@ class VisualTestUtils:
             if dir_path.is_dir() and not any(dir_path.iterdir()):
                 try:
                     dir_path.rmdir()
-                except Exception as e:
+                except OSError as e:
                     logger.warning("Error removing empty directory %s: %s", dir_path, e)
 
         return cleaned_count


### PR DESCRIPTION
## Summary

Narrows `except Exception:` clauses across 26 files to catch specific exception types. Silent broad catches masked bugs and made debugging hard.

**Narrowed by category:**
- File I/O → `OSError`, `FileNotFoundError`, `PermissionError`
- JSON → `json.JSONDecodeError`
- S-expression (sexpdata) → `ExpectClosingBracket`, `ExpectNothing`, `ExpectSExp`, `ValueError`, `TypeError`, `IndexError`
- YAML → `yaml.YAMLError`
- CSV → `csv.Error`, `UnicodeDecodeError`
- Data access → `ValueError`, `KeyError`, `TypeError`, `IndexError`, `AttributeError`
- Subprocess → `SecureSubprocessError`, `KiCadCLIError`, `OSError`

**4 intentional broad catches retained** in `server.py` at cleanup/shutdown/entry-point boundaries, each annotated with `# noqa: BLE001`.

Closes #46

## Test plan

- [x] All 412 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)