### PR TITLE
test: increase coverage threshold to 45%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       run: uv sync --group dev
 
     - name: Run tests
-      run: uv run pytest tests/ -v --cov=kicad_mcp --cov-report=xml --cov-fail-under=37
+      run: uv run pytest tests/ -v --cov=kicad_mcp --cov-report=xml --cov-fail-under=45
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dev:
 
 # Run all tests (matches CI command)
 test:
-	uv run pytest tests/ -v --cov=kicad_mcp --cov-report=xml --cov-fail-under=37
+	uv run pytest tests/ -v --cov=kicad_mcp --cov-report=xml --cov-fail-under=45
 
 # Run unit tests only
 test-unit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html:htmlcov",
     "--cov-report=xml",
-    "--cov-fail-under=37",
+    "--cov-fail-under=45",
     "-ra",
     "--tb=short",
 ]

--- a/tests/unit/utils/test_component_utils_extraction.py
+++ b/tests/unit/utils/test_component_utils_extraction.py
@@ -1,0 +1,278 @@
+"""Tests for component value extraction functions in kicad_mcp.utils.component_utils.
+
+Covers: extract_voltage_from_regulator, extract_frequency_from_value,
+extract_resistance_value, extract_capacitance_value, extract_inductance_value,
+format_value, normalize_component_value, get_component_type,
+get_component_type_from_reference, is_power_component.
+"""
+
+import pytest
+
+from kicad_mcp.utils.component_utils import (
+    extract_capacitance_value,
+    extract_frequency_from_value,
+    extract_inductance_value,
+    extract_resistance_value,
+    extract_voltage_from_regulator,
+    format_value,
+    get_component_type,
+    get_component_type_from_reference,
+    is_power_component,
+    normalize_component_value,
+)
+
+
+class TestExtractVoltageFromRegulator:
+    """Tests for extract_voltage_from_regulator."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("LM7805CT", "5V"),
+            ("LM7812", "12V"),
+            ("LM7905", "5V"),
+            ("LM7912", "12V"),
+            ("AMS1117-3.3", "3.3V"),
+            ("LM1117-3.3", "3.3V"),
+            ("LM1117-5", "5V"),
+            ("LM317", "Adjustable"),
+            ("LM337", "Adjustable (Negative)"),
+            ("MCP1700-3.3", "3.3V"),
+            ("L7805", "5V"),
+            ("Some LDO 5V", "5V"),
+            ("3.3V regulator", "3.3V"),
+        ],
+    )
+    def test_known_regulators(self, value: str, expected: str) -> None:
+        assert extract_voltage_from_regulator(value) == expected
+
+    def test_unknown_returns_unknown(self) -> None:
+        assert extract_voltage_from_regulator("MYSTERY_PART") == "unknown"
+
+    def test_79xx_negative_regulator(self) -> None:
+        # 79xx series pattern
+        result = extract_voltage_from_regulator("LM7909")
+        assert result == "9V"
+
+
+class TestExtractFrequencyFromValue:
+    """Tests for extract_frequency_from_value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Crystal 16MHz", "16.000MHz"),
+            ("32.768kHz", "32.768kHz"),
+            ("8MHz", "8.000MHz"),
+            ("16M", "16.000MHz"),
+            ("32.768k", "32.768kHz"),
+            ("2.4GHz", "2.400GHz"),
+            ("32768", "32.768kHz"),  # special case
+        ],
+    )
+    def test_known_frequencies(self, value: str, expected: str) -> None:
+        assert extract_frequency_from_value(value) == expected
+
+    def test_unknown_returns_unknown(self) -> None:
+        assert extract_frequency_from_value("no_freq_here") == "unknown"
+
+    def test_bare_hz_value(self) -> None:
+        result = extract_frequency_from_value("100Hz")
+        assert result == "100.000Hz"
+
+
+class TestExtractResistanceValue:
+    """Tests for extract_resistance_value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_val", "expected_unit"),
+        [
+            ("10k", 10.0, "kΩ"),
+            ("4R7", 4.7, "Ω"),
+            ("4k7", 4.7, "kΩ"),
+            ("1M", 1.0, "MΩ"),
+            ("100", 100.0, "Ω"),
+            ("2.2k", 2.2, "kΩ"),
+            ("100R", 100.0, "Ω"),
+        ],
+    )
+    def test_resistance_values(self, value: str, expected_val: float, expected_unit: str) -> None:
+        num, unit = extract_resistance_value(value)
+        assert num == pytest.approx(expected_val)
+        assert unit == expected_unit
+
+    def test_empty_string(self) -> None:
+        assert extract_resistance_value("") == (None, None)
+
+
+class TestExtractCapacitanceValue:
+    """Tests for extract_capacitance_value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_val", "expected_unit"),
+        [
+            ("10uF", 10.0, "μF"),
+            ("100nF", 100.0, "nF"),
+            ("22pF", 22.0, "pF"),
+            ("4n7", 4.7, "nF"),
+            ("10u", 10.0, "μF"),
+        ],
+    )
+    def test_capacitance_values(self, value: str, expected_val: float, expected_unit: str) -> None:
+        num, unit = extract_capacitance_value(value)
+        assert num == pytest.approx(expected_val)
+        assert unit == expected_unit
+
+    def test_empty_string(self) -> None:
+        assert extract_capacitance_value("") == (None, None)
+
+
+class TestExtractInductanceValue:
+    """Tests for extract_inductance_value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_val", "expected_unit"),
+        [
+            ("10uH", 10.0, "μH"),
+            ("100mH", 100.0, "mH"),
+            ("4u7", 4.7, "μH"),
+            ("10nH", 10.0, "nH"),
+        ],
+    )
+    def test_inductance_values(self, value: str, expected_val: float, expected_unit: str) -> None:
+        num, unit = extract_inductance_value(value)
+        assert num == pytest.approx(expected_val)
+        assert unit == expected_unit
+
+    def test_empty_string(self) -> None:
+        assert extract_inductance_value("") == (None, None)
+
+
+class TestFormatValue:
+    """Tests for format_value."""
+
+    def test_integer_value(self) -> None:
+        assert format_value(10.0, "kΩ") == "10kΩ"
+
+    def test_float_value(self) -> None:
+        assert format_value(4.7, "kΩ") == "4.7kΩ"
+
+    def test_zero(self) -> None:
+        assert format_value(0.0, "Ω") == "0Ω"
+
+
+class TestNormalizeComponentValue:
+    """Tests for normalize_component_value."""
+
+    def test_resistor(self) -> None:
+        assert normalize_component_value("10k", "R") == "10kΩ"
+
+    def test_capacitor(self) -> None:
+        assert normalize_component_value("100nF", "C") == "100nF"
+
+    def test_inductor(self) -> None:
+        assert normalize_component_value("10uH", "L") == "10μH"
+
+    def test_voltage_regulator(self) -> None:
+        assert normalize_component_value("LM7805", "U") == "5V"
+
+    def test_unknown_type_returns_original(self) -> None:
+        assert normalize_component_value("XYZ", "Q") == "XYZ"
+
+    def test_regulator_unknown_returns_original(self) -> None:
+        assert normalize_component_value("MYSTERY", "U") == "MYSTERY"
+
+
+class TestGetComponentType:
+    """Tests for get_component_type."""
+
+    @pytest.mark.parametrize(
+        ("lib_id", "expected"),
+        [
+            ("Device:R", "resistor"),
+            ("Device:C", "capacitor"),
+            ("Device:L", "inductor"),
+            ("Device:LED", "led"),
+            ("Device:D", "diode"),
+            ("power:GND", "power"),
+            ("power:VCC", "power"),
+            ("Connector:Conn_01x02", "connector"),
+            ("Switch:SW_Push", "switch"),
+            ("MCU_Microchip:ATmega328P", "ic"),
+        ],
+    )
+    def test_lib_id_detection(self, lib_id: str, expected: str) -> None:
+        assert get_component_type(lib_id) == expected
+
+    def test_reference_fallback(self) -> None:
+        assert get_component_type("", "R1") == "resistor"
+        assert get_component_type("", "C5") == "capacitor"
+        assert get_component_type("", "U3") == "ic"
+
+    def test_unknown(self) -> None:
+        assert get_component_type("") == "unknown"
+
+    def test_transistor_npn(self) -> None:
+        assert get_component_type("Transistor_BJT:NPN_EBC") == "transistor"
+
+    def test_resistor_variants(self) -> None:
+        assert get_component_type("Device:R_Small") == "resistor"
+
+    def test_capacitor_variants(self) -> None:
+        assert get_component_type("Device:C_Polarized") == "capacitor"
+
+    def test_inductor_variants(self) -> None:
+        assert get_component_type("Device:L_Core_Ferrite") == "inductor"
+
+
+class TestGetComponentTypeFromReference:
+    """Tests for get_component_type_from_reference."""
+
+    @pytest.mark.parametrize(
+        ("ref", "expected"),
+        [
+            ("R1", "R"),
+            ("C22", "C"),
+            ("U10", "U"),
+            ("LED3", "LED"),
+            ("SW_SPDT2", "SW_SPDT"),
+        ],
+    )
+    def test_reference_prefix(self, ref: str, expected: str) -> None:
+        assert get_component_type_from_reference(ref) == expected
+
+    def test_empty_string(self) -> None:
+        assert get_component_type_from_reference("") == ""
+
+    def test_numeric_only(self) -> None:
+        assert get_component_type_from_reference("123") == ""
+
+
+class TestIsPowerComponent:
+    """Tests for is_power_component."""
+
+    def test_power_reference_prefix(self) -> None:
+        assert is_power_component({"reference": "VR1", "value": "", "lib_id": ""}) is True
+        assert is_power_component({"reference": "PS1", "value": "", "lib_id": ""}) is True
+        assert is_power_component({"reference": "REG1", "value": "", "lib_id": ""}) is True
+
+    def test_power_keywords_in_value(self) -> None:
+        assert is_power_component({"reference": "U1", "value": "VCC", "lib_id": ""}) is True
+        assert (
+            is_power_component({"reference": "U1", "value": "LDO REGULATOR", "lib_id": ""}) is True
+        )
+
+    def test_power_keywords_in_lib_id(self) -> None:
+        assert is_power_component({"reference": "U1", "value": "", "lib_id": "power:GND"}) is True
+
+    def test_regulator_part_numbers(self) -> None:
+        assert is_power_component({"reference": "U1", "value": "LM7805", "lib_id": ""}) is True
+        assert is_power_component({"reference": "U1", "value": "AMS1117", "lib_id": ""}) is True
+
+    def test_non_power_component(self) -> None:
+        assert (
+            is_power_component({"reference": "R1", "value": "10k", "lib_id": "Device:R"}) is False
+        )
+
+    def test_missing_keys_defaults(self) -> None:
+        assert is_power_component({}) is False

--- a/tests/unit/utils/test_drc_history.py
+++ b/tests/unit/utils/test_drc_history.py
@@ -1,0 +1,131 @@
+"""Tests for kicad_mcp.utils.drc_history."""
+
+import os
+
+import pytest
+
+from kicad_mcp.utils.drc_history import (
+    compare_with_previous,
+    ensure_history_dir,
+    get_drc_history,
+    get_project_history_path,
+    save_drc_result,
+)
+
+
+class TestEnsureHistoryDir:
+    """Tests for ensure_history_dir."""
+
+    def test_creates_directory(self, tmp_path, monkeypatch) -> None:
+        target = str(tmp_path / "drc_hist")
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", target)
+        ensure_history_dir()
+        assert os.path.isdir(target)
+
+    def test_idempotent(self, tmp_path, monkeypatch) -> None:
+        target = str(tmp_path / "drc_hist")
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", target)
+        ensure_history_dir()
+        ensure_history_dir()  # should not raise
+
+
+class TestGetProjectHistoryPath:
+    """Tests for get_project_history_path."""
+
+    def test_returns_path_in_history_dir(self, monkeypatch) -> None:
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", "/tmp/drc")
+        path = get_project_history_path("/home/user/project.kicad_pro")
+        assert path.startswith("/tmp/drc/")
+        assert "project.kicad_pro" in path
+        assert path.endswith("_drc_history.json")
+
+    def test_different_projects_different_paths(self, monkeypatch) -> None:
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", "/tmp/drc")
+        p1 = get_project_history_path("/a/project1.kicad_pro")
+        p2 = get_project_history_path("/b/project2.kicad_pro")
+        assert p1 != p2
+
+
+class TestSaveAndGetDrcHistory:
+    """Integration tests for save_drc_result and get_drc_history."""
+
+    @pytest.fixture()
+    def history_dir(self, tmp_path, monkeypatch):
+        target = str(tmp_path / "drc_hist")
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", target)
+        return target
+
+    def test_save_and_retrieve(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        drc_result = {"total_violations": 3, "violation_categories": {"clearance": 2, "width": 1}}
+        save_drc_result(project, drc_result)
+        history = get_drc_history(project)
+        assert len(history) == 1
+        assert history[0]["total_violations"] == 3
+
+    def test_history_sorted_newest_first(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        save_drc_result(project, {"total_violations": 1, "violation_categories": {}})
+        save_drc_result(project, {"total_violations": 5, "violation_categories": {}})
+        history = get_drc_history(project)
+        assert len(history) == 2
+        # Newest first
+        assert history[0]["timestamp"] >= history[1]["timestamp"]
+
+    def test_no_history_returns_empty(self, history_dir) -> None:
+        history = get_drc_history("/nonexistent/project.kicad_pro")
+        assert history == []
+
+    def test_corrupt_file_returns_empty(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        # Write corrupt JSON
+        ensure_history_dir()
+        path = get_project_history_path(project)
+        with open(path, "w") as f:
+            f.write("not valid json{{{")
+        history = get_drc_history(project)
+        assert history == []
+
+    def test_max_entries_capped(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        for i in range(15):
+            save_drc_result(project, {"total_violations": i, "violation_categories": {}})
+        history = get_drc_history(project)
+        assert len(history) <= 10
+
+
+class TestCompareWithPrevious:
+    """Tests for compare_with_previous."""
+
+    @pytest.fixture()
+    def history_dir(self, tmp_path, monkeypatch):
+        target = str(tmp_path / "drc_hist")
+        monkeypatch.setattr("kicad_mcp.utils.drc_history.DRC_HISTORY_DIR", target)
+        return target
+
+    def test_no_history_returns_none(self, history_dir) -> None:
+        result = compare_with_previous(
+            "/fake/project.kicad_pro",
+            {"total_violations": 1, "violation_categories": {}},
+        )
+        assert result is None
+
+    def test_single_entry_returns_none(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        save_drc_result(project, {"total_violations": 3, "violation_categories": {}})
+        result = compare_with_previous(project, {"total_violations": 1, "violation_categories": {}})
+        assert result is None
+
+    def test_comparison_with_two_entries(self, history_dir) -> None:
+        project = "/fake/project.kicad_pro"
+        save_drc_result(project, {"total_violations": 5, "violation_categories": {"a": 3, "b": 2}})
+        save_drc_result(project, {"total_violations": 3, "violation_categories": {"a": 2, "c": 1}})
+
+        current = {"total_violations": 2, "violation_categories": {"a": 1, "d": 1}}
+        result = compare_with_previous(project, current)
+        assert result is not None
+        assert result["current_violations"] == 2
+        assert "change" in result
+        assert "new_categories" in result
+        assert "resolved_categories" in result
+        assert "changed_categories" in result

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -1,0 +1,116 @@
+"""Tests for kicad_mcp.utils.env."""
+
+import os
+
+import pytest
+
+from kicad_mcp.utils.env import find_env_file, get_env_list, load_dotenv
+
+
+class TestLoadDotenv:
+    """Tests for load_dotenv function."""
+
+    def test_load_basic_env_file(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("FOO=bar\nBAZ=qux\n")
+        result = load_dotenv(str(env_file))
+        assert result["FOO"] == "bar"
+        assert result["BAZ"] == "qux"
+        # Clean up
+        os.environ.pop("FOO", None)
+        os.environ.pop("BAZ", None)
+
+    def test_load_skips_comments_and_blank_lines(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("# comment\n\nKEY1=value1\n")
+        result = load_dotenv(str(env_file))
+        assert result == {"KEY1": "value1"}
+        os.environ.pop("KEY1", None)
+
+    def test_load_strips_quotes(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("DOUBLE=\"hello\"\nSINGLE='world'\n")
+        result = load_dotenv(str(env_file))
+        assert result["DOUBLE"] == "hello"
+        assert result["SINGLE"] == "world"
+        os.environ.pop("DOUBLE", None)
+        os.environ.pop("SINGLE", None)
+
+    def test_load_expands_tilde(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_PATH=~/some/path\n")
+        result = load_dotenv(str(env_file))
+        assert "~" not in result["MY_PATH"]
+        assert result["MY_PATH"].endswith("/some/path")
+        os.environ.pop("MY_PATH", None)
+
+    def test_load_nonexistent_file_returns_empty(self) -> None:
+        result = load_dotenv("/nonexistent/path/.env")
+        assert result == {}
+
+    def test_load_sets_environ(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("TEST_ENV_VAR_XYZ=123\n")
+        load_dotenv(str(env_file))
+        assert os.environ.get("TEST_ENV_VAR_XYZ") == "123"
+        os.environ.pop("TEST_ENV_VAR_XYZ", None)
+
+    def test_load_skips_lines_without_equals(self, tmp_path: pytest.TempPathFactory) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("no_equals_here\nVALID=yes\n")
+        result = load_dotenv(str(env_file))
+        assert "no_equals_here" not in result
+        assert result["VALID"] == "yes"
+        os.environ.pop("VALID", None)
+
+
+class TestFindEnvFile:
+    """Tests for find_env_file function."""
+
+    def test_find_in_current_dir(self, tmp_path: pytest.TempPathFactory, monkeypatch) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("X=1\n")
+        monkeypatch.chdir(tmp_path)
+        result = find_env_file()
+        assert result is not None
+        assert result.endswith(".env")
+
+    def test_find_returns_none_when_missing(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = find_env_file()
+        assert result is None
+
+    def test_find_in_parent_dir(self, tmp_path: pytest.TempPathFactory, monkeypatch) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("X=1\n")
+        child = tmp_path / "subdir"
+        child.mkdir()
+        monkeypatch.chdir(child)
+        result = find_env_file()
+        assert result is not None
+
+
+class TestGetEnvList:
+    """Tests for get_env_list function."""
+
+    def test_comma_separated(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST", "a, b, c")
+        result = get_env_list("TEST_LIST")
+        assert result == ["a", "b", "c"]
+
+    def test_empty_default(self) -> None:
+        result = get_env_list("NONEXISTENT_VAR_XYZ123")
+        assert result == []
+
+    def test_custom_default(self, monkeypatch) -> None:
+        # Ensure the var is not set
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        result = get_env_list("MISSING_VAR", default="x,y")
+        assert result == ["x", "y"]
+
+    def test_filters_empty_items(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST2", "a,,b,")
+        result = get_env_list("TEST_LIST2")
+        assert result == ["a", "b"]


### PR DESCRIPTION
## Summary

Adds 107 unit tests across three utility modules to raise coverage from 42.61% to 46.64%, then raises the `--cov-fail-under` threshold from 37 to 45 across pyproject.toml, Makefile, and CI workflow.

**New test files:**
- `tests/unit/utils/test_component_utils_extraction.py` — component reference/value parsing
- `tests/unit/utils/test_drc_history.py` — DRC history save/load/compare
- `tests/unit/utils/test_env.py` — dotenv loading, file finding, list parsing

Closes #47

## Test plan

- [x] All 519 tests pass (412 existing + 107 new)
- [x] Coverage report shows 46.64% total
- [x] Threshold raised to 45% with ~1.6% buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)