### PR TITLE
docs(blueprint): upgrade blueprint to reflect post-0.1 reality

### DIFF
--- a/docs/blueprint/ADR-002-python-toolchain.md
+++ b/docs/blueprint/ADR-002-python-toolchain.md
@@ -3,6 +3,8 @@ id: ADR-002
 title: Python Toolchain Choices (uv, ruff, pytest, hatchling)
 status: accepted
 created: 2026-03-05
+updated: 2026-04-24
+superseded_in_part_by: ADR-004
 ---
 
 # ADR-002: Python Toolchain Choices (uv, ruff, pytest, hatchling)
@@ -78,3 +80,14 @@ pytest is configured via `[tool.pytest.ini_options]` with strict markers, async 
 - mypy is included in the `dev` dependency group for optional static type checking. It is not enforced in CI at this time but is available for local use.
 - bandit is included for security linting and is run in CI as a separate job (`security-scan`).
 - The pre-commit configuration wires ruff, conventional commits validation (commitlint), trufflehog secret scanning, and actionlint for GitHub Actions workflow validation.
+
+## Updates (2026-04-24)
+
+Subsequent toolchain changes that refine but do not fundamentally alter this ADR:
+
+- **Type checker: mypy → `ty`.** The mypy row of the decision table is superseded by **ADR-004**. `mypy` has been removed from the `dev` dependency group; `ty` (Astral) is the active type checker.
+- **Dead-code detection: `vulture` added.** Added to the `dev` group (`vulture>=2.11`) and configured under `[tool.vulture]` in `pyproject.toml`. An allowlist lives at `vulture_allowlist.py` for decorators (`@mcp.tool`, `@pytest.fixture`, etc.) whose callers are external to static analysis. Run via `uv run vulture` or `make dead-code`.
+- **Dependency vulnerability scanning: `pip-audit` added to CI.** The `security` job in `.github/workflows/ci.yml` invokes `uv run --with pip-audit pip-audit`. Run with `continue-on-error: true` so advisories surface without blocking merges until triaged.
+- **Coverage floor raised 30% → 45%.** Both `[tool.pytest.ini_options] addopts` and the CI `--cov-fail-under` flag now require 45%. The 80%+ long-term target from the PRD is unchanged.
+- **Logging replaces `print()`.** The codebase no longer uses `print()` for diagnostic output; all modules emit through the standard `logging` module. This is a convention, not a tooling change, but is recorded here so future contributors know to follow it.
+- **Docstring style.** Google-style docstrings are the project convention across `kicad_mcp/`.

--- a/docs/blueprint/ADR-003-sexpr-parsing.md
+++ b/docs/blueprint/ADR-003-sexpr-parsing.md
@@ -3,6 +3,7 @@ id: ADR-003
 title: S-Expression Parsing Approach for KiCad File Formats
 status: accepted
 created: 2026-03-05
+updated: 2026-04-24
 ---
 
 # ADR-003: S-Expression Parsing Approach for KiCad File Formats
@@ -80,3 +81,8 @@ The KiCad Python API (`pcbnew`) and full `kicad-cli` delegation for all operatio
 
 - `defusedxml` is used for any XML parsing (some older KiCad export formats use XML) to guard against XML entity expansion attacks, consistent with the project's security guidelines.
 - The version management utility (`kicad_mcp/utils/version.py`) centralizes the KiCad file format version constants so that generated files declare the correct version token regardless of which tool module produces them.
+
+## Updates (2026-04-24)
+
+- **Wire connectivity tracing is now implemented.** The "Pin-level connectivity analysis is incomplete" item in the Negative consequences above is resolved. A dedicated `ConnectivityEngine` (`kicad_mcp/utils/connectivity.py`) walks schematic wire geometry, merges coincident endpoints, and produces a net dictionary consumed by the netlist builder (`kicad_mcp/utils/netlist_parser.py`). Bus entries and hierarchical labels remain follow-up work, but the common case — component pins connected through explicit wire segments and labels — is covered.
+- **Text-to-schematic parser hardening.** The shorthand-connection path now emits wires when one pin is omitted, and the YAML front-end tolerates list-of-lists `connections` forms. These are maintenance fixes to the approach described above, not a change of direction.

--- a/docs/blueprint/ADR-004-ty-type-checker.md
+++ b/docs/blueprint/ADR-004-ty-type-checker.md
@@ -1,0 +1,54 @@
+---
+id: ADR-004
+title: Replace mypy with ty for Python Type Checking
+status: accepted
+created: 2026-04-24
+supersedes: "ADR-002 (type checker selection only)"
+---
+
+# ADR-004: Replace mypy with ty for Python Type Checking
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-002 included mypy in the `dev` dependency group as an optional static type checker. Type checking was not enforced in CI, so mypy saw limited use. Two developments since then prompted reconsideration:
+
+1. Astral — the maintainer of `uv` and `ruff`, both already adopted by this project — released **`ty`**, a Rust-based Python type checker intended as a faster, more ergonomic alternative to mypy.
+2. The project accumulated enough typed surface area (async tool functions, dataclasses, typed dicts for netlist and DRC results) that running a checker regularly became valuable, and mypy's per-run cost on a cold cache was noticeable.
+
+The options considered were:
+
+- **Keep mypy** and invest in tuning its configuration and cache behavior.
+- **Switch to pyright** (Microsoft), which is fast and has broad editor integration but is a Node.js tool, adding a non-Python runtime dependency.
+- **Switch to `ty`** (Astral), which is Rust-based, distributes as a Python wheel, and shares the same maintainer as the existing `uv` + `ruff` stack.
+
+`ty` is still pre-1.0 (`0.0.1a*` release line at time of adoption). This is a known risk.
+
+## Decision
+
+The project uses **`ty`** as its Python type checker, replacing `mypy`. The `dev` dependency group declares `ty>=0.0.1a6,<0.1` and `mypy` is removed. A minimal `[tool.ty]` table is present in `pyproject.toml` to reserve configuration scope; project-wide strictness tuning is deferred until `ty` stabilises.
+
+As with mypy, type checking is not yet a blocking gate in CI. It is run locally by contributors and expected to be promoted to a required CI job once `ty` reaches a stable release.
+
+## Consequences
+
+### Positive
+
+- `ty` runs in a fraction of the time mypy took on the same codebase, making it practical to run on every save during development.
+- Aligning on a single maintainer (Astral) for `uv`, `ruff`, and `ty` reduces the number of tool ecosystems contributors must track.
+- Distribution as a Python wheel keeps installation inside the `uv sync --group dev` flow with no extra runtimes required.
+- A focused cleanup pass (PR #80) resolved the set of real type errors `ty` surfaced, improving the codebase's actual type correctness independent of the tool choice.
+
+### Negative
+
+- `ty` is pre-1.0. Its CLI flags, error codes, and configuration schema are expected to change before a stable release. Configuration in `pyproject.toml` may need updates tracking upstream releases.
+- Error messages and rule coverage are not yet fully at parity with mypy. Edge cases (complex generics, protocol conformance) may be diagnosed differently or not at all.
+- Editor integrations for `ty` are less mature than for mypy or pyright. Contributors using non-Astral-aware editors may need to fall back to running `ty` from the shell.
+
+### Neutral
+
+- The type-checker switch does not change the type annotation style in the codebase. Existing annotations compatible with mypy continue to work under `ty`.
+- ADR-002's decision to use `ruff` for lint/format and `pytest` for testing is unaffected; only the mypy row of that ADR's decision table is superseded by this one.

--- a/docs/blueprint/PRD.md
+++ b/docs/blueprint/PRD.md
@@ -3,6 +3,7 @@ id: PRD-001
 title: KiCad MCP Server Product Requirements
 status: accepted
 created: 2026-03-05
+updated: 2026-04-24
 ---
 
 # PRD-001: KiCad MCP Server
@@ -105,7 +106,7 @@ The Model Context Protocol (MCP) defines a standard interface for giving AI assi
 
 - All new functionality must be developed following Test-Driven Development (TDD): write a failing test before implementing.
 - The test suite must be runnable with `uv run pytest tests/ -v`.
-- Coverage must not fall below 30% (enforced by CI); the target coverage is 80%+.
+- Coverage must not fall below 45% (enforced by CI); the target coverage is 80%+.
 - Tests must be organized into `tests/unit/`, `tests/integration/`, and `tests/fixtures/`.
 
 #### NFR-5: Configuration

--- a/docs/blueprint/manifest.yaml
+++ b/docs/blueprint/manifest.yaml
@@ -2,7 +2,8 @@ blueprint:
   project: kicad-mcp
   description: Model Context Protocol server for KiCad electronic design automation files
   created: "2026-03-05"
-  version: "0.1.0"
+  updated: "2026-04-24"
+  version: "0.2.0"
 
 artifacts:
   - id: PRD-001
@@ -11,6 +12,7 @@ artifacts:
     title: KiCad MCP Server Product Requirements
     status: accepted
     created: "2026-03-05"
+    updated: "2026-04-24"
 
   - id: ADR-001
     path: docs/blueprint/ADR-001-mcp-framework.md
@@ -25,6 +27,8 @@ artifacts:
     title: Python Toolchain Choices (uv, ruff, pytest, hatchling)
     status: accepted
     created: "2026-03-05"
+    updated: "2026-04-24"
+    superseded_in_part_by: ADR-004
 
   - id: ADR-003
     path: docs/blueprint/ADR-003-sexpr-parsing.md
@@ -32,3 +36,12 @@ artifacts:
     title: S-Expression Parsing Approach for KiCad File Formats
     status: accepted
     created: "2026-03-05"
+    updated: "2026-04-24"
+
+  - id: ADR-004
+    path: docs/blueprint/ADR-004-ty-type-checker.md
+    type: adr
+    title: Replace mypy with ty for Python Type Checking
+    status: accepted
+    created: "2026-04-24"
+    supersedes: ADR-002 (type checker selection only)


### PR DESCRIPTION
## Summary

The blueprint in `docs/blueprint/` was cut on 2026-03-05 at project version 0.1.0 and has drifted from the codebase over the last ~7 weeks. This PR reconciles the documented architecture with what actually shipped.

### Changes

- **New `ADR-004: Replace mypy with ty for Python Type Checking`** — records the rationale for adopting Astral's `ty` (PR #72), notes the pre-1.0 risk, and supersedes only the type-checker row of ADR-002.
- **`ADR-002` — added Updates (2026-04-24) section** covering:
  - mypy → `ty` (pointer to ADR-004)
  - `vulture` added to the `dev` group for dead-code detection (PR #70)
  - `pip-audit` added to the CI security job (PR #67)
  - Coverage floor raised 30% → 45% (PR #82)
  - `print()` → `logging` migration complete (PRs #78, #68)
  - Google-style docstring convention
- **`ADR-003` — added Updates (2026-04-24) section** closing the "pin-level connectivity analysis is incomplete" negative consequence, now that `ConnectivityEngine` (PR #62) traces wire geometry into the netlist builder. Also notes text-to-schematic parser hardening (PRs #83, #66, #73).
- **`PRD.md`** — NFR-4 coverage requirement updated 30% → 45% to match `pyproject.toml` and the CI gate.
- **`manifest.yaml`** — blueprint version bumped to `0.2.0`, ADR-004 registered, `updated` timestamps and supersession links added to the affected artifacts.

No ADRs are retroactively edited; updates are appended as dated "Updates" sections so the original decisions remain auditable.

## Test plan

- [ ] `docs/blueprint/manifest.yaml` parses as valid YAML (verified locally with `python3 -c "import yaml; yaml.safe_load(open('docs/blueprint/manifest.yaml'))"`).
- [ ] Each ADR still opens cleanly in a Markdown viewer with its frontmatter intact.
- [ ] Cross-references check out: ADR-002 points to ADR-004, ADR-004 names ADR-002 under `supersedes`, and manifest entries agree.
- [ ] PRD NFR-4 matches `[tool.pytest.ini_options] --cov-fail-under=45` in `pyproject.toml` and the `--cov-fail-under=45` flag in `.github/workflows/ci.yml`.

https://claude.ai/code/session_01HqziocZLNMkiAgpdKYyxXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqziocZLNMkiAgpdKYyxXy)_