### PR TITLE
chore: sync paul356's upstream fixes (env-reload + null ctx)

### DIFF
--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -26,7 +26,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
     """
 
     @mcp.tool()
-    async def analyze_bom(project_path: str, ctx: Context) -> dict[str, Any]:
+    async def analyze_bom(project_path: str, ctx: Context | None) -> dict[str, Any]:
         """Analyze a KiCad project's Bill of Materials.
 
         This tool will look for BOM files related to a KiCad project and provide
@@ -43,12 +43,14 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(project_path):
             logger.warning("Project not found: %s", project_path)
-            await ctx.info(f"Project not found: {project_path}")
+            if ctx:
+                await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
-        await ctx.info(f"Looking for BOM files related to {os.path.basename(project_path)}")
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(f"Looking for BOM files related to {os.path.basename(project_path)}")
 
         # Get all project files
         files = get_project_files(project_path)
@@ -62,14 +64,16 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
         if not bom_files:
             logger.info("No BOM files found for project")
-            await ctx.info("No BOM files found for project")
+            if ctx:
+                await ctx.info("No BOM files found for project")
             return {
                 "success": False,
                 "error": "No BOM files found. Export a BOM from KiCad first.",
                 "project_path": project_path,
             }
 
-        await ctx.report_progress(30, 100)
+        if ctx:
+            await ctx.report_progress(30, 100)
 
         # Analyze each BOM file
         results = {
@@ -84,7 +88,8 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
         for file_type, file_path in bom_files.items():
             try:
-                await ctx.info(f"Analyzing {os.path.basename(file_path)}")
+                if ctx:
+                    await ctx.info(f"Analyzing {os.path.basename(file_path)}")
 
                 # Parse the BOM file
                 bom_data, format_info = parse_bom_file(file_path)
@@ -113,7 +118,8 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 logger.error("Error analyzing BOM file %s: %s", file_path, e, exc_info=True)
                 results["bom_files"][file_type] = {"path": file_path, "error": str(e)}
 
-        await ctx.report_progress(70, 100)
+        if ctx:
+            await ctx.report_progress(70, 100)
 
         # Generate overall component summary
         if total_components > 0:
@@ -157,13 +163,14 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 )
                 results["component_summary"]["currency"] = currency
 
-        await ctx.report_progress(100, 100)
-        await ctx.info(f"BOM analysis complete: found {total_components} components")
+        if ctx:
+            await ctx.report_progress(100, 100)
+            await ctx.info(f"BOM analysis complete: found {total_components} components")
 
         return results
 
     @mcp.tool()
-    async def export_bom_csv(project_path: str, ctx: Context) -> dict[str, Any]:
+    async def export_bom_csv(project_path: str, ctx: Context | None) -> dict[str, Any]:
         """Export a Bill of Materials for a KiCad project.
 
         This tool attempts to generate a CSV BOM file for a KiCad project.
@@ -180,11 +187,13 @@ def register_bom_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(project_path):
             logger.warning("Project not found: %s", project_path)
-            await ctx.info(f"Project not found: {project_path}")
+            if ctx:
+                await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
+        if ctx:
+            await ctx.report_progress(10, 100)
 
         # Get all project files
         files = get_project_files(project_path)
@@ -192,36 +201,45 @@ def register_bom_tools(mcp: FastMCP) -> None:
         # We need the schematic file to generate a BOM
         if "schematic" not in files:
             logger.warning("Schematic file not found in project")
-            await ctx.info("Schematic file not found in project")
+            if ctx:
+                await ctx.info("Schematic file not found in project")
             return {"success": False, "error": "Schematic file not found"}
 
         schematic_file = files["schematic"]
         project_dir = os.path.dirname(project_path)
         project_name = os.path.basename(project_path)[:-10]  # Remove .kicad_pro extension
 
-        await ctx.report_progress(20, 100)
-        await ctx.info(f"Found schematic file: {os.path.basename(schematic_file)}")
+        if ctx:
+            await ctx.report_progress(20, 100)
+            await ctx.info(f"Found schematic file: {os.path.basename(schematic_file)}")
 
         # Export BOM using command-line tools
         export_result = {"success": False}
         try:
-            await ctx.info("Attempting to export BOM using command-line tools...")
+            if ctx:
+                await ctx.info("Attempting to export BOM using command-line tools...")
             export_result = await export_bom_with_cli(
                 schematic_file, project_dir, project_name, ctx
             )
         except (OSError, ValueError) as e:
             logger.error("Error exporting BOM with CLI: %s", e, exc_info=True)
-            await ctx.info(f"Error using command-line tools: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error using command-line tools: {str(e)}")
             export_result = {"success": False, "error": str(e)}
 
-        await ctx.report_progress(100, 100)
+        if ctx:
+            await ctx.report_progress(100, 100)
 
         if export_result.get("success", False):
-            await ctx.info(
-                f"BOM exported successfully to {export_result.get('output_file', 'unknown location')}"
-            )
+            if ctx:
+                await ctx.info(
+                    f"BOM exported successfully to {export_result.get('output_file', 'unknown location')}"
+                )
         else:
-            await ctx.info(f"Failed to export BOM: {export_result.get('error', 'Unknown error')}")
+            if ctx:
+                await ctx.info(
+                    f"Failed to export BOM: {export_result.get('error', 'Unknown error')}"
+                )
 
         return export_result
 
@@ -575,7 +593,7 @@ def analyze_bom_data(
 
 
 async def export_bom_with_cli(
-    schematic_file: str, output_dir: str, project_name: str, ctx: Context
+    schematic_file: str, output_dir: str, project_name: str, ctx: Context | None
 ) -> dict[str, Any]:
     """Export a BOM using KiCad command-line tools.
 
@@ -592,7 +610,8 @@ async def export_bom_with_cli(
     from kicad_mcp.utils.secure_subprocess import SecureSubprocessError, get_subprocess_runner
 
     logger.info("Exporting BOM using CLI tools via SecureSubprocessRunner")
-    await ctx.report_progress(40, 100)
+    if ctx:
+        await ctx.report_progress(40, 100)
 
     # Output file path
     output_file = os.path.join(output_dir, f"{project_name}_bom.csv")
@@ -602,7 +621,8 @@ async def export_bom_with_cli(
 
     try:
         logger.info("Running BOM export command via SecureSubprocessRunner")
-        await ctx.report_progress(60, 100)
+        if ctx:
+            await ctx.report_progress(60, 100)
 
         runner = get_subprocess_runner()
         process = runner.run_kicad_command(
@@ -631,7 +651,8 @@ async def export_bom_with_cli(
                 "output_file": output_file,
             }
 
-        await ctx.report_progress(80, 100)
+        if ctx:
+            await ctx.report_progress(80, 100)
 
         # Read the first few lines of the BOM to verify it's valid
         with open(output_file) as f:

--- a/kicad_mcp/tools/drc_tools.py
+++ b/kicad_mcp/tools/drc_tools.py
@@ -68,7 +68,7 @@ def register_drc_tools(mcp: FastMCP) -> None:
         }
 
     @mcp.tool()
-    async def run_drc_check(project_path: str, ctx: Context) -> dict[str, Any]:
+    async def run_drc_check(project_path: str, ctx: Context | None) -> dict[str, Any]:
         """Run a Design Rule Check on a KiCad PCB file.
 
         Args:
@@ -94,14 +94,16 @@ def register_drc_tools(mcp: FastMCP) -> None:
         logger.debug("Found PCB file: %s", pcb_file)
 
         # Report progress to user
-        await ctx.report_progress(10, 100)
-        await ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(f"Starting DRC check on {os.path.basename(pcb_file)}")
 
         # Run DRC using the appropriate approach
         drc_results = None
 
         logger.debug("Using kicad-cli for DRC")
-        await ctx.info("Using KiCad CLI for DRC check...")
+        if ctx:
+            await ctx.info("Using KiCad CLI for DRC check...")
         drc_results = await run_drc_via_cli(pcb_file, ctx)
 
         # Process and save results if successful
@@ -114,24 +116,26 @@ def register_drc_tools(mcp: FastMCP) -> None:
             if comparison:
                 drc_results["comparison"] = comparison
 
-                if comparison["change"] < 0:
-                    await ctx.info(
-                        f"Great progress! You've fixed {abs(comparison['change'])} DRC violations since the last check."
-                    )
-                elif comparison["change"] > 0:
-                    await ctx.info(
-                        f"Found {comparison['change']} new DRC violations since the last check."
-                    )
-                else:
-                    await ctx.info(
-                        "No change in the number of DRC violations since the last check."
-                    )
+                if ctx:
+                    if comparison["change"] < 0:
+                        await ctx.info(
+                            f"Great progress! You've fixed {abs(comparison['change'])} DRC violations since the last check."
+                        )
+                    elif comparison["change"] > 0:
+                        await ctx.info(
+                            f"Found {comparison['change']} new DRC violations since the last check."
+                        )
+                    else:
+                        await ctx.info(
+                            "No change in the number of DRC violations since the last check."
+                        )
         elif drc_results:
             pass
         else:
             pass
 
         # Complete progress
-        await ctx.report_progress(100, 100)
+        if ctx:
+            await ctx.report_progress(100, 100)
 
         return drc_results or {"success": False, "error": "DRC check failed with an unknown error"}

--- a/kicad_mcp/tools/export_tools.py
+++ b/kicad_mcp/tools/export_tools.py
@@ -30,7 +30,7 @@ def register_export_tools(mcp: FastMCP) -> None:
     """
 
     @mcp.tool()
-    async def generate_pcb_thumbnail(project_path: str, ctx: Context):
+    async def generate_pcb_thumbnail(project_path: str, ctx: Context | None):
         """Generate a thumbnail image of a KiCad PCB layout using kicad-cli.
 
         Args:
@@ -41,8 +41,10 @@ def register_export_tools(mcp: FastMCP) -> None:
             Image object containing the PCB thumbnail or None if generation failed
         """
         try:
-            # Access the context
-            app_context = ctx.request_context.lifespan_context
+            # Access the context (with null check)
+            app_context = None
+            if ctx:
+                app_context = ctx.request_context.lifespan_context
             # Removed check for kicad_modules_available as we now use CLI
 
             logger.info("Generating thumbnail via CLI for project: %s", project_path)
@@ -54,14 +56,16 @@ def register_export_tools(mcp: FastMCP) -> None:
                 )
             except PathValidationError as e:
                 logger.warning("Invalid project path: %s", e)
-                await ctx.info(f"Invalid project path: {e}")
+                if ctx:
+                    await ctx.info(f"Invalid project path: {e}")
                 return None
 
             # Get PCB file from project
             files = get_project_files(validated_project_path)
             if "pcb" not in files:
                 logger.warning("PCB file not found in project")
-                await ctx.info("PCB file not found in project")
+                if ctx:
+                    await ctx.info("PCB file not found in project")
                 return None
 
             pcb_file = files["pcb"]
@@ -69,29 +73,36 @@ def register_export_tools(mcp: FastMCP) -> None:
 
             # Check cache
             cache_key = f"thumbnail_cli_{pcb_file}_{os.path.getmtime(pcb_file)}"
-            if hasattr(app_context, "cache") and cache_key in app_context.cache:
+            if app_context and hasattr(app_context, "cache") and cache_key in app_context.cache:
                 logger.debug("Using cached CLI thumbnail for %s", pcb_file)
                 return app_context.cache[cache_key]
 
-            await ctx.report_progress(PROGRESS_CONSTANTS["start"], PROGRESS_CONSTANTS["complete"])
-            await ctx.info(f"Generating thumbnail for {os.path.basename(pcb_file)} using kicad-cli")
+            if ctx:
+                await ctx.report_progress(
+                    PROGRESS_CONSTANTS["start"], PROGRESS_CONSTANTS["complete"]
+                )
+                await ctx.info(
+                    f"Generating thumbnail for {os.path.basename(pcb_file)} using kicad-cli"
+                )
 
             # Use command-line tools
             try:
                 thumbnail = await generate_thumbnail_with_cli(pcb_file, ctx)
                 if thumbnail:
                     # Cache the result if possible
-                    if hasattr(app_context, "cache"):
+                    if app_context and hasattr(app_context, "cache"):
                         app_context.cache[cache_key] = thumbnail
                     logger.info("Thumbnail generated successfully via CLI.")
                     return thumbnail
                 else:
                     logger.warning("generate_thumbnail_with_cli returned None")
-                    await ctx.info("Failed to generate thumbnail using kicad-cli.")
+                    if ctx:
+                        await ctx.info("Failed to generate thumbnail using kicad-cli.")
                     return None
             except (OSError, ValueError) as e:
                 logger.error("Error calling generate_thumbnail_with_cli: %s", e, exc_info=True)
-                await ctx.info(f"Error generating thumbnail with kicad-cli: {str(e)}")
+                if ctx:
+                    await ctx.info(f"Error generating thumbnail with kicad-cli: {str(e)}")
                 return None
 
         except asyncio.CancelledError:
@@ -99,11 +110,12 @@ def register_export_tools(mcp: FastMCP) -> None:
             raise  # Re-raise to let MCP know the task was cancelled
         except (OSError, ValueError) as e:
             logger.error("Unexpected error in thumbnail generation: %s", e)
-            await ctx.info(f"Error: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error: {str(e)}")
             return None
 
     @mcp.tool()
-    async def generate_project_thumbnail(project_path: str, ctx: Context):
+    async def generate_project_thumbnail(project_path: str, ctx: Context | None):
         """Generate a thumbnail of a KiCad project's PCB layout (Alias for generate_pcb_thumbnail)."""
         # This function now just calls the main CLI-based thumbnail generator
         logger.info(
@@ -114,7 +126,7 @@ def register_export_tools(mcp: FastMCP) -> None:
 
 
 # Helper functions for thumbnail generation
-async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
+async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
     """Generate PCB thumbnail using command line tools.
     This is a fallback method when the kicad Python module is not available or fails.
 
@@ -127,14 +139,18 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
     """
     try:
         logger.info("Attempting to generate thumbnail using KiCad CLI tools")
-        await ctx.report_progress(PROGRESS_CONSTANTS["detection"], PROGRESS_CONSTANTS["complete"])
+        if ctx:
+            await ctx.report_progress(
+                PROGRESS_CONSTANTS["detection"], PROGRESS_CONSTANTS["complete"]
+            )
 
         # Validate and sanitize PCB file path
         try:
             validated_pcb_file = validate_kicad_file(pcb_file, "pcb", must_exist=True)
         except PathValidationError as e:
             logger.warning("Invalid PCB file path: %s", e)
-            await ctx.info(f"Invalid PCB file path: {e}")
+            if ctx:
+                await ctx.info(f"Invalid PCB file path: {e}")
             return None
 
         # --- Determine Output Path ---
@@ -143,15 +159,17 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
             validated_project_dir = validate_directory(project_dir, must_exist=True)
         except PathValidationError as e:
             logger.warning("Invalid project directory: %s", e)
-            await ctx.info(f"Invalid project directory: {e}")
+            if ctx:
+                await ctx.info(f"Invalid project directory: {e}")
             return None
 
         project_name = os.path.splitext(os.path.basename(validated_pcb_file))[0]
         output_file = os.path.join(validated_project_dir, f"{project_name}_thumbnail.svg")
         # ---------------------------
 
-        await ctx.report_progress(PROGRESS_CONSTANTS["setup"], PROGRESS_CONSTANTS["complete"])
-        await ctx.info("Using KiCad command line tools for thumbnail generation")
+        if ctx:
+            await ctx.report_progress(PROGRESS_CONSTANTS["setup"], PROGRESS_CONSTANTS["complete"])
+            await ctx.info("Using KiCad command line tools for thumbnail generation")
 
         # Create secure subprocess runner
         subprocess_runner = SecureSubprocessRunner()
@@ -169,7 +187,10 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
         ]
 
         logger.debug("Running KiCad CLI command: %s", " ".join(command_args))
-        await ctx.report_progress(PROGRESS_CONSTANTS["processing"], PROGRESS_CONSTANTS["complete"])
+        if ctx:
+            await ctx.report_progress(
+                PROGRESS_CONSTANTS["processing"], PROGRESS_CONSTANTS["complete"]
+            )
 
         # Run the command using secure subprocess runner
         try:
@@ -185,13 +206,15 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
                 logger.error("Command failed with code %d", process.returncode)
                 logger.error("Stderr: %s", process.stderr)
                 logger.error("Stdout: %s", process.stdout)
-                await ctx.info(f"KiCad CLI command failed: {process.stderr or process.stdout}")
+                if ctx:
+                    await ctx.info(f"KiCad CLI command failed: {process.stderr or process.stdout}")
                 return None
 
             logger.debug("Command successful: %s", process.stdout)
-            await ctx.report_progress(
-                PROGRESS_CONSTANTS["finishing"], PROGRESS_CONSTANTS["complete"]
-            )
+            if ctx:
+                await ctx.report_progress(
+                    PROGRESS_CONSTANTS["finishing"], PROGRESS_CONSTANTS["complete"]
+                )
 
             # Check if the output file was created
             if not os.path.exists(output_file):
@@ -203,20 +226,23 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
                 img_data = f.read()
 
             logger.info("Successfully generated thumbnail with CLI, size: %d bytes", len(img_data))
-            await ctx.report_progress(
-                PROGRESS_CONSTANTS["validation"], PROGRESS_CONSTANTS["complete"]
-            )
-            # Inform user about the saved file
-            await ctx.info(f"Thumbnail saved to: {output_file}")
+            if ctx:
+                await ctx.report_progress(
+                    PROGRESS_CONSTANTS["validation"], PROGRESS_CONSTANTS["complete"]
+                )
+                # Inform user about the saved file
+                await ctx.info(f"Thumbnail saved to: {output_file}")
             return Image(data=img_data, format="svg")
 
         except SecureSubprocessError as e:
             logger.error("Secure subprocess error: %s", e)
-            await ctx.info(f"KiCad CLI command failed: {e}")
+            if ctx:
+                await ctx.info(f"KiCad CLI command failed: {e}")
             return None
         except OSError as e:
             logger.error("Error running CLI command: %s", e, exc_info=True)
-            await ctx.info(f"Error running KiCad CLI: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error running KiCad CLI: {str(e)}")
             return None
 
     except asyncio.CancelledError:
@@ -224,5 +250,6 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context):
         raise
     except (OSError, ValueError) as e:
         logger.error("Unexpected error in CLI thumbnail generation: %s", e)
-        await ctx.info(f"Unexpected error: {str(e)}")
+        if ctx:
+            await ctx.info(f"Unexpected error: {str(e)}")
         return None

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -24,7 +24,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
     """
 
     @mcp.tool()
-    async def extract_schematic_netlist(schematic_path: str, ctx: Context) -> dict[str, Any]:
+    async def extract_schematic_netlist(schematic_path: str, ctx: Context | None) -> dict[str, Any]:
         """Extract netlist information from a KiCad schematic.
 
         This tool parses a KiCad schematic file and extracts comprehensive
@@ -41,37 +41,44 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(schematic_path):
             logger.warning("Schematic file not found: %s", schematic_path)
-            await ctx.info(f"Schematic file not found: {schematic_path}")
+            if ctx:
+                await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
-        await ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
 
         # Extract netlist information
         try:
-            await ctx.report_progress(20, 100)
-            await ctx.info("Parsing schematic structure...")
+            if ctx:
+                await ctx.report_progress(20, 100)
+                await ctx.info("Parsing schematic structure...")
 
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
                 logger.error("Error extracting netlist: %s", netlist_data["error"])
-                await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+                if ctx:
+                    await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
-            await ctx.report_progress(60, 100)
-            await ctx.info(
-                f"Extracted {netlist_data['component_count']} components and {netlist_data['net_count']} nets"
-            )
+            if ctx:
+                await ctx.report_progress(60, 100)
+                await ctx.info(
+                    f"Extracted {netlist_data['component_count']} components and {netlist_data['net_count']} nets"
+                )
 
             # Analyze the netlist
-            await ctx.report_progress(70, 100)
-            await ctx.info("Analyzing netlist data...")
+            if ctx:
+                await ctx.report_progress(70, 100)
+                await ctx.info("Analyzing netlist data...")
 
             analysis_results = analyze_netlist(netlist_data)
 
-            await ctx.report_progress(90, 100)
+            if ctx:
+                await ctx.report_progress(90, 100)
 
             # Build result
             result = {
@@ -85,18 +92,20 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             }
 
             # Complete progress
-            await ctx.report_progress(100, 100)
-            await ctx.info("Netlist extraction complete")
+            if ctx:
+                await ctx.report_progress(100, 100)
+                await ctx.info("Netlist extraction complete")
 
             return result
 
         except (OSError, ValueError, KeyError) as e:
             logger.error("Error extracting netlist: %s", e, exc_info=True)
-            await ctx.info(f"Error extracting netlist: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
-    async def extract_project_netlist(project_path: str, ctx: Context) -> dict[str, Any]:
+    async def extract_project_netlist(project_path: str, ctx: Context | None) -> dict[str, Any]:
         """Extract netlist from a KiCad project's schematic.
 
         This tool finds the schematic associated with a KiCad project
@@ -113,11 +122,13 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(project_path):
             logger.warning("Project not found: %s", project_path)
-            await ctx.info(f"Project not found: {project_path}")
+            if ctx:
+                await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
+        if ctx:
+            await ctx.report_progress(10, 100)
 
         # Get the schematic file
         try:
@@ -125,15 +136,18 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             if "schematic" not in files:
                 logger.warning("Schematic file not found in project")
-                await ctx.info("Schematic file not found in project")
+                if ctx:
+                    await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
             logger.info("Found schematic file: %s", schematic_path)
-            await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
+            if ctx:
+                await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Extract netlist
-            await ctx.report_progress(20, 100)
+            if ctx:
+                await ctx.report_progress(20, 100)
 
             # Call the schematic netlist extraction
             result = await extract_schematic_netlist(schematic_path, ctx)  # ty: ignore[call-non-callable]
@@ -146,11 +160,14 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
         except (OSError, ValueError, KeyError) as e:
             logger.error("Error extracting project netlist: %s", e, exc_info=True)
-            await ctx.info(f"Error extracting project netlist: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error extracting project netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
-    async def analyze_schematic_connections(schematic_path: str, ctx: Context) -> dict[str, Any]:
+    async def analyze_schematic_connections(
+        schematic_path: str, ctx: Context | None
+    ) -> dict[str, Any]:
         """Analyze connections in a KiCad schematic.
 
         This tool provides detailed analysis of component connections,
@@ -167,12 +184,14 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(schematic_path):
             logger.warning("Schematic file not found: %s", schematic_path)
-            await ctx.info(f"Schematic file not found: {schematic_path}")
+            if ctx:
+                await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
-        await ctx.info(f"Extracting netlist from: {os.path.basename(schematic_path)}")
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(f"Extracting netlist from: {os.path.basename(schematic_path)}")
 
         # Extract netlist information
         try:
@@ -180,13 +199,16 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             if "error" in netlist_data:
                 logger.error("Error extracting netlist: %s", netlist_data["error"])
-                await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+                if ctx:
+                    await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
-            await ctx.report_progress(40, 100)
+            if ctx:
+                await ctx.report_progress(40, 100)
 
             # Advanced connection analysis
-            await ctx.info("Performing connection analysis...")
+            if ctx:
+                await ctx.info("Performing connection analysis...")
 
             analysis = {
                 "component_count": netlist_data["component_count"],
@@ -210,7 +232,8 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                         analysis["component_types"][comp_type] = 0
                     analysis["component_types"][comp_type] += 1
 
-            await ctx.report_progress(60, 100)
+            if ctx:
+                await ctx.report_progress(60, 100)
 
             # Identify power nets
             nets = netlist_data.get("nets", {})
@@ -223,7 +246,8 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                 else:
                     analysis["signal_nets"].append({"name": net_name, "pin_count": len(pins)})
 
-            await ctx.report_progress(80, 100)
+            if ctx:
+                await ctx.report_progress(80, 100)
 
             # Check for potential issues
             # 1. Nets with only one connection (floating)
@@ -243,25 +267,28 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             # 2. Power pins without connections
             # This would require more detailed parsing of the schematic
 
-            await ctx.report_progress(90, 100)
+            if ctx:
+                await ctx.report_progress(90, 100)
 
             # Build result
             result = {"success": True, "schematic_path": schematic_path, "analysis": analysis}
 
             # Complete progress
-            await ctx.report_progress(100, 100)
-            await ctx.info("Connection analysis complete")
+            if ctx:
+                await ctx.report_progress(100, 100)
+                await ctx.info("Connection analysis complete")
 
             return result
 
         except (OSError, ValueError, KeyError) as e:
             logger.error("Error analyzing connections: %s", e, exc_info=True)
-            await ctx.info(f"Error analyzing connections: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error analyzing connections: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
     async def find_component_connections(
-        project_path: str, component_ref: str, ctx: Context
+        project_path: str, component_ref: str, ctx: Context | None
     ) -> dict[str, Any]:
         """Find all connections for a specific component in a KiCad project.
 
@@ -282,11 +309,13 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
         if not os.path.exists(project_path):
             logger.warning("Project not found: %s", project_path)
-            await ctx.info(f"Project not found: {project_path}")
+            if ctx:
+                await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
+        if ctx:
+            await ctx.report_progress(10, 100)
 
         # Get the schematic file
         try:
@@ -294,29 +323,34 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             if "schematic" not in files:
                 logger.warning("Schematic file not found in project")
-                await ctx.info("Schematic file not found in project")
+                if ctx:
+                    await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
             logger.info("Found schematic file: %s", schematic_path)
-            await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
+            if ctx:
+                await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Extract netlist
-            await ctx.report_progress(30, 100)
-            await ctx.info(f"Extracting netlist to find connections for {component_ref}...")
+            if ctx:
+                await ctx.report_progress(30, 100)
+                await ctx.info(f"Extracting netlist to find connections for {component_ref}...")
 
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
                 logger.error("Failed to extract netlist: %s", netlist_data["error"])
-                await ctx.info(f"Failed to extract netlist: {netlist_data['error']}")
+                if ctx:
+                    await ctx.info(f"Failed to extract netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
             # Check if component exists in the netlist
             components = netlist_data.get("components", {})
             if component_ref not in components:
                 logger.warning("Component %s not found in schematic", component_ref)
-                await ctx.info(f"Component {component_ref} not found in schematic")
+                if ctx:
+                    await ctx.info(f"Component {component_ref} not found in schematic")
                 return {
                     "success": False,
                     "error": f"Component {component_ref} not found in schematic",
@@ -327,8 +361,9 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             component_info = components[component_ref]
 
             # Find connections
-            await ctx.report_progress(50, 100)
-            await ctx.info("Finding connections...")
+            if ctx:
+                await ctx.report_progress(50, 100)
+                await ctx.info("Finding connections...")
 
             nets = netlist_data.get("nets", {})
             connections = []
@@ -368,8 +403,9 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                     connected_nets.append(net_name)
 
             # Analyze the connections
-            await ctx.report_progress(70, 100)
-            await ctx.info("Analyzing connections...")
+            if ctx:
+                await ctx.report_progress(70, 100)
+                await ctx.info("Analyzing connections...")
 
             # Categorize connections by pin function (if possible)
             pin_functions = {}
@@ -408,12 +444,16 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                 "total_connections": len(connections),
             }
 
-            await ctx.report_progress(100, 100)
-            await ctx.info(f"Found {len(connections)} connections for component {component_ref}")
+            if ctx:
+                await ctx.report_progress(100, 100)
+                await ctx.info(
+                    f"Found {len(connections)} connections for component {component_ref}"
+                )
 
             return result
 
         except (OSError, ValueError, KeyError) as e:
             logger.error("Error finding component connections: %s", e, exc_info=True)
-            await ctx.info(f"Error finding component connections: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error finding component connections: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/pattern_tools.py
+++ b/kicad_mcp/tools/pattern_tools.py
@@ -30,7 +30,7 @@ def register_pattern_tools(mcp: FastMCP) -> None:
     """
 
     @mcp.tool()
-    async def identify_circuit_patterns(schematic_path: str, ctx: Context) -> dict[str, Any]:
+    async def identify_circuit_patterns(schematic_path: str, ctx: Context | None) -> dict[str, Any]:
         """Identify common circuit patterns in a KiCad schematic.
 
         This tool analyzes a schematic to recognize common circuit blocks such as:
@@ -49,34 +49,40 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             Dictionary with identified circuit patterns
         """
         if not os.path.exists(schematic_path):
-            await ctx.info(f"Schematic file not found: {schematic_path}")
+            if ctx:
+                await ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
-        await ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
+        if ctx:
+            await ctx.report_progress(10, 100)
+            await ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
 
         try:
             # Extract netlist information
-            await ctx.report_progress(20, 100)
-            await ctx.info("Parsing schematic structure...")
+            if ctx:
+                await ctx.report_progress(20, 100)
+                await ctx.info("Parsing schematic structure...")
 
             netlist_data = extract_netlist(schematic_path)
 
             if "error" in netlist_data:
-                await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
+                if ctx:
+                    await ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data["error"]}
 
             # Analyze components and nets
-            await ctx.report_progress(30, 100)
-            await ctx.info("Analyzing components and connections...")
+            if ctx:
+                await ctx.report_progress(30, 100)
+                await ctx.info("Analyzing components and connections...")
 
             components = netlist_data.get("components", {})
             nets = netlist_data.get("nets", {})
 
             # Start pattern recognition
-            await ctx.report_progress(50, 100)
-            await ctx.info("Identifying circuit patterns...")
+            if ctx:
+                await ctx.report_progress(50, 100)
+                await ctx.info("Identifying circuit patterns...")
 
             identified_patterns = {
                 "power_supply_circuits": [],
@@ -90,33 +96,40 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             }
 
             # Identify power supply circuits
-            await ctx.report_progress(60, 100)
+            if ctx:
+                await ctx.report_progress(60, 100)
             identified_patterns["power_supply_circuits"] = identify_power_supplies(components, nets)
 
             # Identify amplifier circuits
-            await ctx.report_progress(70, 100)
+            if ctx:
+                await ctx.report_progress(70, 100)
             identified_patterns["amplifier_circuits"] = identify_amplifiers(components, nets)
 
             # Identify filter circuits
-            await ctx.report_progress(75, 100)
+            if ctx:
+                await ctx.report_progress(75, 100)
             identified_patterns["filter_circuits"] = identify_filters(components, nets)
 
             # Identify oscillator circuits
-            await ctx.report_progress(80, 100)
+            if ctx:
+                await ctx.report_progress(80, 100)
             identified_patterns["oscillator_circuits"] = identify_oscillators(components, nets)
 
             # Identify digital interface circuits
-            await ctx.report_progress(85, 100)
+            if ctx:
+                await ctx.report_progress(85, 100)
             identified_patterns["digital_interface_circuits"] = identify_digital_interfaces(
                 components, nets
             )
 
             # Identify microcontroller circuits
-            await ctx.report_progress(90, 100)
+            if ctx:
+                await ctx.report_progress(90, 100)
             identified_patterns["microcontroller_circuits"] = identify_microcontrollers(components)
 
             # Identify sensor interface circuits
-            await ctx.report_progress(95, 100)
+            if ctx:
+                await ctx.report_progress(95, 100)
             identified_patterns["sensor_interface_circuits"] = identify_sensor_interfaces(
                 components, nets
             )
@@ -134,19 +147,23 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             result["total_patterns_found"] = total_patterns
 
             # Complete progress
-            await ctx.report_progress(100, 100)
-            await ctx.info(
-                f"Pattern recognition complete. Found {total_patterns} circuit patterns."
-            )
+            if ctx:
+                await ctx.report_progress(100, 100)
+                await ctx.info(
+                    f"Pattern recognition complete. Found {total_patterns} circuit patterns."
+                )
 
             return result
 
         except (OSError, ValueError, KeyError) as e:
-            await ctx.info(f"Error identifying circuit patterns: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error identifying circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
-    async def analyze_project_circuit_patterns(project_path: str, ctx: Context) -> dict[str, Any]:
+    async def analyze_project_circuit_patterns(
+        project_path: str, ctx: Context | None
+    ) -> dict[str, Any]:
         """Identify circuit patterns in a KiCad project's schematic.
 
         Args:
@@ -157,22 +174,26 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             Dictionary with identified circuit patterns
         """
         if not os.path.exists(project_path):
-            await ctx.info(f"Project not found: {project_path}")
+            if ctx:
+                await ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         # Report progress
-        await ctx.report_progress(10, 100)
+        if ctx:
+            await ctx.report_progress(10, 100)
 
         # Get the schematic file
         try:
             files = get_project_files(project_path)
 
             if "schematic" not in files:
-                await ctx.info("Schematic file not found in project")
+                if ctx:
+                    await ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
 
             schematic_path = files["schematic"]
-            await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
+            if ctx:
+                await ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
 
             # Identify patterns in the schematic
             result = await identify_circuit_patterns(schematic_path, ctx)  # ty: ignore[call-non-callable]
@@ -184,5 +205,6 @@ def register_pattern_tools(mcp: FastMCP) -> None:
             return result
 
         except (OSError, ValueError, KeyError) as e:
-            await ctx.info(f"Error analyzing project circuit patterns: {str(e)}")
+            if ctx:
+                await ctx.info(f"Error analyzing project circuit patterns: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/utils/kicad_utils.py
+++ b/kicad_mcp/utils/kicad_utils.py
@@ -8,13 +8,7 @@ import os
 import sys  # Add sys import
 from typing import Any
 
-from kicad_mcp.config import (
-    ADDITIONAL_SEARCH_PATHS,
-    KICAD_APP_PATH,
-    KICAD_EXTENSIONS,
-    KICAD_USER_DIR,
-    TIMEOUT_CONSTANTS,
-)
+from kicad_mcp import config
 
 from .path_validator import PathValidationError, validate_directory, validate_kicad_file
 from .secure_subprocess import SecureSubprocessError, SecureSubprocessRunner
@@ -32,9 +26,9 @@ def find_kicad_projects() -> list[dict[str, Any]]:
     projects = []
     logging.info("Attempting to find KiCad projects...")  # Log start
     # Search directories to look for KiCad projects
-    raw_search_dirs = [KICAD_USER_DIR] + ADDITIONAL_SEARCH_PATHS
-    logging.info(f"Raw KICAD_USER_DIR: '{KICAD_USER_DIR}'")
-    logging.info(f"Raw ADDITIONAL_SEARCH_PATHS: {ADDITIONAL_SEARCH_PATHS}")
+    raw_search_dirs = [config.KICAD_USER_DIR] + config.ADDITIONAL_SEARCH_PATHS
+    logging.info(f"Raw KICAD_USER_DIR: '{config.KICAD_USER_DIR}'")
+    logging.info(f"Raw ADDITIONAL_SEARCH_PATHS: {config.ADDITIONAL_SEARCH_PATHS}")
     logging.info(f"Raw search list before expansion: {raw_search_dirs}")
 
     expanded_search_dirs = []
@@ -59,7 +53,7 @@ def find_kicad_projects() -> list[dict[str, Any]]:
             # Use followlinks=True to follow symlinks if needed
             for root, _, files in os.walk(validated_dir, followlinks=True):
                 for file in files:
-                    if file.endswith(KICAD_EXTENSIONS["project"]):
+                    if file.endswith(config.KICAD_EXTENSIONS["project"]):
                         project_path = os.path.join(root, file)
                         # Check if it's a real file and not a broken symlink
                         if not os.path.isfile(project_path):
@@ -119,7 +113,7 @@ def find_kicad_projects_in_dirs(search_directories: list[str]) -> list[dict[str,
 
             for root, _, files in os.walk(validated_dir, followlinks=True):
                 for file in files:
-                    if file.endswith(KICAD_EXTENSIONS["project"]):
+                    if file.endswith(config.KICAD_EXTENSIONS["project"]):
                         project_path = os.path.join(root, file)
                         if not os.path.isfile(project_path):
                             continue
@@ -160,7 +154,7 @@ def get_project_name_from_path(project_path: str) -> str:
         Project name without extension
     """
     basename = os.path.basename(project_path)
-    return basename[: -len(KICAD_EXTENSIONS["project"])]
+    return basename[: -len(config.KICAD_EXTENSIONS["project"])]
 
 
 def open_kicad_project(project_path: str) -> dict[str, Any]:
@@ -185,7 +179,7 @@ def open_kicad_project(project_path: str) -> dict[str, Any]:
 
         if sys.platform == "darwin":  # macOS
             # On MacOS, use the 'open' command to open the project in KiCad
-            cmd = ["open", "-a", KICAD_APP_PATH, validated_project_path]
+            cmd = ["open", "-a", config.KICAD_APP_PATH, validated_project_path]
             allowed_commands = ["open"]
         elif sys.platform == "linux":  # Linux
             # On Linux, use 'xdg-open'
@@ -197,7 +191,9 @@ def open_kicad_project(project_path: str) -> dict[str, Any]:
 
         # Execute command using secure subprocess runner
         result = subprocess_runner.run_safe_command(
-            cmd, allowed_commands=allowed_commands, timeout=TIMEOUT_CONSTANTS["application_open"]
+            cmd,
+            allowed_commands=allowed_commands,
+            timeout=config.TIMEOUT_CONSTANTS["application_open"],
         )
 
         return {

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import logging  # Import logging module
 import os
 
 # Must import config BEFORE env potentially overrides it via os.environ
-from kicad_mcp.config import ADDITIONAL_SEARCH_PATHS, KICAD_USER_DIR
+from kicad_mcp import config
 from kicad_mcp.server import create_server
 from kicad_mcp.utils.env import load_dotenv
 
@@ -25,8 +25,8 @@ logging.basicConfig(
 # ---------------------
 
 logging.info("--- Server Starting --- ")
-logging.info(f"Initial KICAD_USER_DIR from config.py: {KICAD_USER_DIR}")
-logging.info(f"Initial ADDITIONAL_SEARCH_PATHS from config.py: {ADDITIONAL_SEARCH_PATHS}")
+logging.info(f"Initial KICAD_USER_DIR from config.py: {config.KICAD_USER_DIR}")
+logging.info(f"Initial ADDITIONAL_SEARCH_PATHS from config.py: {config.ADDITIONAL_SEARCH_PATHS}")
 
 # Get PID for logging (already used by basicConfig)
 _PID = os.getpid()
@@ -51,8 +51,6 @@ logging.info(f"os.environ['KICAD_SEARCH_PATHS'] after load_dotenv: {effective_se
 try:
     import importlib
 
-    from kicad_mcp import config
-
     importlib.reload(config)  # Attempt to force re-reading config
     logging.info(f"Effective KICAD_USER_DIR from config.py after reload: {config.KICAD_USER_DIR}")
     logging.info(
@@ -60,9 +58,11 @@ try:
     )
 except Exception as e:
     logging.error(f"Could not reload config: {e}")
-    logging.info(f"Using potentially stale KICAD_USER_DIR from initial import: {KICAD_USER_DIR}")
     logging.info(
-        f"Using potentially stale ADDITIONAL_SEARCH_PATHS from initial import: {ADDITIONAL_SEARCH_PATHS}"
+        f"Using potentially stale KICAD_USER_DIR from initial import: {config.KICAD_USER_DIR}"
+    )
+    logging.info(
+        f"Using potentially stale ADDITIONAL_SEARCH_PATHS from initial import: {config.ADDITIONAL_SEARCH_PATHS}"
     )
 
 if __name__ == "__main__":
@@ -70,10 +70,12 @@ if __name__ == "__main__":
         logging.info("Starting KiCad MCP server process")
 
         # Print search paths from config
-        logging.info(f"Using KiCad user directory: {KICAD_USER_DIR}")  # Changed print to logging
-        if ADDITIONAL_SEARCH_PATHS:
+        logging.info(
+            f"Using KiCad user directory: {config.KICAD_USER_DIR}"
+        )  # Changed print to logging
+        if config.ADDITIONAL_SEARCH_PATHS:
             logging.info(
-                f"Additional search paths: {', '.join(ADDITIONAL_SEARCH_PATHS)}"
+                f"Additional search paths: {', '.join(config.ADDITIONAL_SEARCH_PATHS)}"
             )  # Changed print to logging
         else:
             logging.info("No additional search paths configured")  # Changed print to logging


### PR DESCRIPTION
## Description

Brings in the only two non-merge commits that exist in `upstream/main` but not in `origin/main`: paul356's env-var misuse fix (upstream #29) and the null-ctx workaround (upstream #33). Both are cherry-picked rather than merged so we keep a linear history and retain our local improvements.

This is prep work to enable upstream PRs. With these in `main`, future feature branches cut from `upstream/main` no longer conflict with paul356's changes — each upstream PR can focus on a single concern.

## Related Issue(s)

No local issue. Upstream commits: `c16968b` (env vars) and `c0e3f2b` (null ctx).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Commits

1. **`fix(config): resolve env-reload staleness by deferring config lookups`**
   Import `kicad_mcp.config` as a module and reference `config.X` at call time instead of binding individual names at import time. This allows `importlib.reload(config)` in `main.py` to actually update the values used by `find_kicad_projects()` after `.env` loads.

2. **`fix(tools): tolerate null ctx in MCP tool handlers`**
   Accept `ctx: Context | None` in tool signatures and guard every `ctx.info()` / `ctx.report_progress()` call with `if ctx:`. Prevents `AttributeError` when FastMCP invokes a tool without a live context. Touches `bom_tools`, `drc_tools`, `export_tools`, `netlist_tools`, `pattern_tools` (`drc_impl/cli_drc.py` already had `Context | None = None`).

## Conflict Resolution Notes

Both commits conflicted with our fork's subsequent refactoring. Resolved by preserving our local improvements on top of paul356's pattern:
- `await ctx.info(...)` — kept our `await` additions; paul356's version was missing them
- Modern `dict[str, Any]` / `list[...]` type hints — kept ours
- `path_validator`, `SecureSubprocessRunner`, narrowed exception handlers — kept

Authorship and co-author trailers preserved for paul356.

## Testing Performed

- [x] Added new unit tests (N/A — no behavior change beyond ctx guarding)
- [x] Manually tested on macOS
- [x] New and existing unit tests pass with my changes

```
uv run pytest tests/unit -x -q --no-cov
489 passed in 0.88s
```

```
uv run ruff check .
All checks passed!
uv run ty check kicad_mcp/
All checks passed!
```

## Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass with my changes

## Additional Notes

**Why the "behind upstream" count won't drop to zero after merge**: cherry-picks create new SHAs, so `git log upstream/main ^main` will still list paul356's original commits. Functionally we have the fixes. The other ~17 upstream-only commits are phantom — they're our own early PRs that were re-squashed by upstream before divergence, not representable in our linear history.