### PR TITLE
feat(claude): add upstream-pr skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,7 @@
       "Bash(gh issue *)",
       "Bash(pre-commit *)",
       "Bash(gitleaks *)",
+      "Bash(.claude/skills/upstream-pr/scripts/*)",
       "mcp__context7",
       "mcp__sequential-thinking"
     ]

--- a/.claude/skills/upstream-pr/SKILL.md
+++ b/.claude/skills/upstream-pr/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: upstream-pr
+description: Cherry-pick a commit from this fork onto a fresh branch cut from upstream/main (lamaalrajih/kicad-mcp), ready to PR back upstream. Use when the user wants to contribute a fix back to upstream, submit an upstream PR, backport to lamaalrajih, or asks "can we send X upstream?".
+---
+
+# Upstream Contribution Workflow
+
+This fork (`laurigates/kicad-mcp`) has substantially diverged from
+`lamaalrajih/kicad-mcp`. Direct rebase is not viable. For
+upstream-bound PRs, branch off `upstream/main` and cherry-pick a single
+commit onto it.
+
+## Eligibility check (always first)
+
+Many of our changes touch fork-only files (`text_to_schematic.py`,
+`sexpr_handler.py`, `visualization_tools.py`, `circuit_tools.py`,
+…) and cannot land standalone — they require their predecessor
+features to be PR'd upstream first.
+
+Run:
+
+```bash
+./.claude/skills/upstream-pr/scripts/check-eligibility.sh <sha>
+```
+
+Exit code 0 = every file the commit touches exists upstream → safe to
+proceed. Exit code 1 = at least one fork-only file → stop and tell the
+user the change isn't standalone-PR-able.
+
+## Prepare the branch
+
+```bash
+./.claude/skills/upstream-pr/scripts/prepare-branch.sh <topic-slug> <sha>
+```
+
+This:
+1. Verifies a clean working tree
+2. Re-runs the eligibility check
+3. Fetches upstream
+4. Creates `pr-upstream/<topic-slug>` from `upstream/main`
+5. Cherry-picks `<sha>`
+6. Reports any conflict files
+
+Resolve conflicts manually. Preserve **upstream's surrounding shape**,
+not ours — the goal is the smallest readable diff against upstream.
+
+## Commit-message scrubbing
+
+Before pushing, amend the commit message to remove fork-local context:
+
+- **Strip local issue references** — `Closes #74`, `Addresses #19`, etc.
+  Those numbers point to our fork's tracker, not upstream's.
+- **Strip Claude trailers** — `Co-authored-by: Claude ...`,
+  `🤖 Generated with [Claude Code]...`. Upstream doesn't follow that
+  convention.
+- **Soften fork-specific tooling** — if the body cites a tool upstream
+  doesn't run (`bandit B607`, `ty`, `vulture`), describe the underlying
+  problem instead.
+- **Keep the conventional-commit prefix** — `fix(security):`,
+  `feat(parser):`, etc.
+
+Use:
+
+```bash
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git -c core.commentChar='|' commit --amend -m "..."
+```
+
+The `PRE_COMMIT_ALLOW_NO_CONFIG=1` is needed because upstream has no
+`.pre-commit-config.yaml` and our locally-installed pre-commit hook
+otherwise refuses the commit.
+
+## Diff hygiene
+
+- **Don't bundle formatter cleanups** with the fix. Keep upstream's
+  existing import order even if our linter would reformat.
+- **One commit per PR.** If the cherry-pick produced multiple commits
+  (rare), squash before pushing.
+- **Verify with `git diff upstream/main..HEAD`** before pushing — every
+  hunk should be defensible to a maintainer who has never seen our
+  fork.
+
+## Push and open the PR
+
+```bash
+git push origin pr-upstream/<topic-slug>
+
+gh pr create --repo lamaalrajih/kicad-mcp --base main \
+  --head laurigates:pr-upstream/<topic-slug> \
+  --title "<conventional-commit subject>" \
+  --body "<see body template below>"
+```
+
+### PR body template
+
+Mirror upstream's PR template structure:
+
+```markdown
+## Description
+
+<one or two paragraphs explaining the problem and the fix from
+the maintainer's perspective — not from our fork's perspective>
+
+## Related Issue(s)
+
+None.  <or upstream issue numbers only>
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+
+## Testing Performed
+
+- [x] Manually tested on macOS
+- [x] `uv run pytest tests/unit -x -q` — N passed
+
+## Notes
+
+Originally authored on a downstream fork; the branch was cut from
+`lamaalrajih/kicad-mcp:main` and a single commit cherry-picked onto
+it so it applies cleanly.
+```
+
+## Reference
+
+The first PR opened with this workflow:
+https://github.com/lamaalrajih/kicad-mcp/pull/53

--- a/.claude/skills/upstream-pr/SKILL.md
+++ b/.claude/skills/upstream-pr/SKILL.md
@@ -52,6 +52,34 @@ This:
 Resolve conflicts manually. Preserve **upstream's surrounding shape**,
 not ours — the goal is the smallest readable diff against upstream.
 
+## When cherry-pick fails: re-derive on upstream
+
+If the cherry-pick produces dozens of conflict blocks across multiple
+files (typical when upstream and fork have drifted heavily on shared
+modules), abort and re-derive instead of fighting hunks.
+
+```bash
+git cherry-pick --abort
+git checkout -b pr-upstream/<topic-slug> upstream/main
+# Re-apply the change against upstream's actual current files.
+```
+
+Re-derive is the right call when:
+
+- The fork commit performs a **mechanical, re-applicable transform**
+  (e.g. `print()` → logging, deprecation rename, lint-rule
+  auto-fixes) — the rules transfer cleanly even if line numbers don't.
+- Upstream's version of the file has **additional lines our fork
+  removed** — re-derive lets you cover them with the same heuristic
+  rather than rationalizing missing hunks.
+- The cherry-pick conflict count exceeds roughly **20 blocks across
+  >2 files**.
+
+Heuristic: extract the original commit's `before → after` map (e.g.
+`git show <sha> | grep -E '^[-+].*pattern'`) and use it as the rulebook
+when re-applying against upstream. The PR body should disclose the
+re-derive (see template below).
+
 ## Commit-message scrubbing
 
 Before pushing, amend the commit message to remove fork-local context:
@@ -80,12 +108,40 @@ otherwise refuses the commit.
 ## Diff hygiene
 
 - **Don't bundle formatter cleanups** with the fix. Keep upstream's
-  existing import order even if our linter would reformat.
+  existing import order even if our linter would reformat. (Upstream
+  may have unusual indentation — e.g. 21-space rather than 20-space
+  blocks. Preserve it; Edit-tool replacements that change leading
+  whitespace by even one character will break the parse.)
 - **One commit per PR.** If the cherry-pick produced multiple commits
   (rare), squash before pushing.
 - **Verify with `git diff upstream/main..HEAD`** before pushing — every
   hunk should be defensible to a maintainer who has never seen our
   fork.
+
+### Pre-flight: prove you didn't introduce regressions
+
+For refactor / cleanup PRs, verify lint and test parity against the
+**pristine upstream baseline**, not against our fork. Use a stash
+roundtrip to A/B compare:
+
+```bash
+# Baseline (pristine upstream/main):
+git stash push -- <changed-files>
+uv run ruff check --output-format=concise <changed-files> 2>&1 | tail -1   # error count
+uv run pytest tests/ -q 2>&1 | tail -1                                     # pass count
+git stash pop
+
+# After (with your changes): run the same two commands and compare.
+```
+
+Both numbers must match (or improve). The pre-flight catches: stray
+formatter touches, accidental import reordering, indentation drift
+from Edit-tool replacements. Quote both numbers in the PR body's
+"Testing Performed" section.
+
+Also run `python3 -c "import ast; ast.parse(open(F).read())"` on every
+edited Python file — catches indentation breaks that ruff might miss
+on already-warning-laden upstream code.
 
 ## Push and open the PR
 
@@ -130,5 +186,10 @@ it so it applies cleanly.
 
 ## Reference
 
-The first PR opened with this workflow:
-https://github.com/lamaalrajih/kicad-mcp/pull/53
+PRs opened with this workflow, by path:
+
+| PR | Path | Notes |
+|---|---|---|
+| [#53](https://github.com/lamaalrajih/kicad-mcp/pull/53) | cherry-pick | First PR; clean apply |
+| [#54](https://github.com/lamaalrajih/kicad-mcp/pull/54) | cherry-pick + 1 conflict | CI workflow; resolved by keeping upstream's shape |
+| [#55](https://github.com/lamaalrajih/kicad-mcp/pull/55) | re-derive | 5-file refactor; fork drift made cherry-pick infeasible |

--- a/.claude/skills/upstream-pr/SKILL.md
+++ b/.claude/skills/upstream-pr/SKILL.md
@@ -23,9 +23,17 @@ Run:
 ./.claude/skills/upstream-pr/scripts/check-eligibility.sh <sha>
 ```
 
-Exit code 0 = every file the commit touches exists upstream → safe to
-proceed. Exit code 1 = at least one fork-only file → stop and tell the
-user the change isn't standalone-PR-able.
+Exit codes:
+
+- **0** — every file the commit touches exists upstream and content is
+  novel → safe to proceed.
+- **1** — at least one fork-only file → stop and tell the user the
+  change isn't standalone-PR-able.
+- **3** — content already applied upstream under a different SHA →
+  nothing to PR. The script reports the matching upstream commit. This
+  catches re-applied content (e.g. maintainer re-merges or squashes)
+  via `git patch-id --stable` matching against every non-merge commit
+  on `upstream/main`.
 
 ## Prepare the branch
 

--- a/.claude/skills/upstream-pr/scripts/check-eligibility.sh
+++ b/.claude/skills/upstream-pr/scripts/check-eligibility.sh
@@ -3,15 +3,22 @@
 #
 # Usage: check-eligibility.sh <sha>
 #
-# A commit is "eligible" if every file it touches already exists on
-# upstream/main. If the commit creates a fork-only file (or modifies
-# one), the change cannot land standalone — its predecessor feature
-# must be PR'd upstream first.
+# A commit is "eligible" if its content is novel (not already applied
+# upstream under a different SHA) AND every file it touches already
+# exists on upstream/main. If the commit creates a fork-only file (or
+# modifies one), the change cannot land standalone — its predecessor
+# feature must be PR'd upstream first.
+#
+# Patch-id matching catches the case where upstream has re-applied our
+# change with a different SHA (e.g. via a maintainer re-merge or
+# squash). `git patch-id --stable` produces a content hash robust
+# against rebases, cherry-picks, and trivial whitespace differences.
 #
 # Exit codes:
-#   0  every touched file exists upstream
+#   0  every touched file exists upstream and content is novel
 #   1  at least one fork-only file
 #   2  invalid arguments / git error
+#   3  content already applied upstream under a different SHA
 
 set -euo pipefail
 
@@ -34,6 +41,40 @@ fi
 
 echo "Commit: $(git log -1 --format='%h %s' "$sha")"
 echo
+
+# --- Patch-id pre-check ---------------------------------------------------
+#
+# If the commit's content already exists on upstream/main under any SHA,
+# there is nothing to PR. Compute patch-id for the target and compare
+# against patch-ids of all non-merge commits on upstream/main.
+
+target_patch=$(git show "$sha" | git patch-id --stable | awk '{print $1}')
+
+if [[ -n "$target_patch" ]]; then
+    # `awk ... exit` closes the pipe early on a match, which would
+    # SIGPIPE-kill the upstream patch-id producer and surface as 141
+    # under `set -o pipefail`. Disable pipefail just for this block.
+    set +o pipefail
+    match=$(
+        git log --no-merges --format=%H upstream/main \
+        | while read -r u; do
+            printf '%s %s\n' "$(git show "$u" | git patch-id --stable | awk '{print $1}')" "$u"
+          done \
+        | awk -v t="$target_patch" '$1 == t { print $2; exit }'
+    )
+    set -o pipefail
+
+    if [[ -n "$match" ]]; then
+        match_subject=$(git log -1 --format='%s' "$match")
+        echo "ALREADY APPLIED — content matches upstream commit $(git rev-parse --short "$match")"
+        echo "  (\"$match_subject\")"
+        echo
+        echo "Nothing to PR; this change is already on upstream/main with a different SHA."
+        exit 3
+    fi
+fi
+
+# --- File-existence check -------------------------------------------------
 
 mapfile -t touched < <(git show --name-only --format= "$sha" | sed '/^$/d')
 

--- a/.claude/skills/upstream-pr/scripts/check-eligibility.sh
+++ b/.claude/skills/upstream-pr/scripts/check-eligibility.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Check whether a commit can be cleanly cherry-picked to upstream/main.
+#
+# Usage: check-eligibility.sh <sha>
+#
+# A commit is "eligible" if every file it touches already exists on
+# upstream/main. If the commit creates a fork-only file (or modifies
+# one), the change cannot land standalone — its predecessor feature
+# must be PR'd upstream first.
+#
+# Exit codes:
+#   0  every touched file exists upstream
+#   1  at least one fork-only file
+#   2  invalid arguments / git error
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <sha>" >&2
+    exit 2
+fi
+
+sha="$1"
+
+if ! git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
+    echo "error: '$sha' is not a valid commit" >&2
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet upstream/main >/dev/null; then
+    echo "error: upstream/main not found. Run 'git fetch upstream' first." >&2
+    exit 2
+fi
+
+echo "Commit: $(git log -1 --format='%h %s' "$sha")"
+echo
+
+mapfile -t touched < <(git show --name-only --format= "$sha" | sed '/^$/d')
+
+if [[ ${#touched[@]} -eq 0 ]]; then
+    echo "error: commit touches no files" >&2
+    exit 2
+fi
+
+missing=()
+for path in "${touched[@]}"; do
+    if git cat-file -e "upstream/main:$path" 2>/dev/null; then
+        printf '  ✓ %s\n' "$path"
+    else
+        printf '  ✗ %s (fork-only)\n' "$path"
+        missing+=("$path")
+    fi
+done
+
+echo
+if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "ELIGIBLE — all ${#touched[@]} file(s) exist on upstream/main."
+    exit 0
+fi
+
+echo "NOT ELIGIBLE — ${#missing[@]} of ${#touched[@]} file(s) are fork-only:"
+for path in "${missing[@]}"; do
+    printf '  - %s\n' "$path"
+done
+echo
+echo "The predecessor feature must be PR'd upstream before this commit can land."
+exit 1

--- a/.claude/skills/upstream-pr/scripts/prepare-branch.sh
+++ b/.claude/skills/upstream-pr/scripts/prepare-branch.sh
@@ -40,11 +40,21 @@ fi
 # --- Eligibility -----------------------------------------------------------
 
 echo "==> Checking eligibility..."
-if ! "$script_dir/check-eligibility.sh" "$sha"; then
-    echo
-    echo "Aborting — commit is not standalone-PR-able to upstream." >&2
-    exit 2
-fi
+elig_rc=0
+"$script_dir/check-eligibility.sh" "$sha" || elig_rc=$?
+case "$elig_rc" in
+    0) ;;
+    3)
+        echo
+        echo "Aborting — commit already applied upstream, nothing to PR." >&2
+        exit 2
+        ;;
+    *)
+        echo
+        echo "Aborting — commit is not standalone-PR-able to upstream." >&2
+        exit 2
+        ;;
+esac
 
 # --- Branch + cherry-pick --------------------------------------------------
 

--- a/.claude/skills/upstream-pr/scripts/prepare-branch.sh
+++ b/.claude/skills/upstream-pr/scripts/prepare-branch.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Cut a branch from upstream/main and cherry-pick a commit onto it.
+#
+# Usage: prepare-branch.sh <topic-slug> <sha>
+#
+# Creates branch `pr-upstream/<topic-slug>` from `upstream/main`,
+# attempts to cherry-pick <sha>, and reports any conflicts that need
+# manual resolution.
+#
+# Exit codes:
+#   0  branch created and cherry-pick succeeded cleanly
+#   1  cherry-pick produced conflicts (branch exists, ready for manual resolution)
+#   2  invalid arguments, ineligible commit, or git precondition failure
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <topic-slug> <sha>" >&2
+    exit 2
+fi
+
+topic="$1"
+sha="$2"
+branch="pr-upstream/$topic"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Preconditions ---------------------------------------------------------
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree has uncommitted changes; commit or stash first" >&2
+    exit 2
+fi
+
+if git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
+    echo "error: branch '$branch' already exists" >&2
+    echo "delete it with: git branch -D $branch" >&2
+    exit 2
+fi
+
+# --- Eligibility -----------------------------------------------------------
+
+echo "==> Checking eligibility..."
+if ! "$script_dir/check-eligibility.sh" "$sha"; then
+    echo
+    echo "Aborting — commit is not standalone-PR-able to upstream." >&2
+    exit 2
+fi
+
+# --- Branch + cherry-pick --------------------------------------------------
+
+echo
+echo "==> Fetching upstream..."
+git fetch upstream
+
+echo
+echo "==> Creating branch '$branch' from upstream/main..."
+git checkout -b "$branch" upstream/main
+
+echo
+echo "==> Cherry-picking $sha..."
+if git cherry-pick "$sha"; then
+    echo
+    echo "SUCCESS — cherry-pick clean."
+    echo
+    echo "Next steps:"
+    echo "  1. Review:  git diff upstream/main..HEAD"
+    echo "  2. Scrub commit message (strip local issue refs, Claude trailers, etc.):"
+    echo "     PRE_COMMIT_ALLOW_NO_CONFIG=1 git -c core.commentChar='|' commit --amend"
+    echo "  3. Push:    git push origin $branch"
+    echo "  4. Open PR: gh pr create --repo lamaalrajih/kicad-mcp --base main \\"
+    echo "                --head laurigates:$branch ..."
+    exit 0
+fi
+
+echo
+echo "CONFLICTS — resolve manually, then run 'git cherry-pick --continue'."
+echo
+echo "Conflicted files:"
+git diff --name-only --diff-filter=U | sed 's/^/  - /'
+echo
+echo "Reminder: preserve upstream's surrounding shape, not ours."
+exit 1


### PR DESCRIPTION
## Description

Codifies the cherry-pick-from-upstream workflow we established when opening upstream PR [#53](https://github.com/lamaalrajih/kicad-mcp/pull/53).

The skill lives at `.claude/skills/upstream-pr/` and packages two helper scripts plus the SKILL.md that triggers when the user asks about contributing back to upstream.

## Related Issue(s)

None.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## What's in the PR

```
.claude/skills/upstream-pr/
├── SKILL.md
└── scripts/
    ├── check-eligibility.sh
    └── prepare-branch.sh
```

**`check-eligibility.sh <sha>`** — lists every file the commit touches and verifies each exists on `upstream/main`. Exits 1 if any file is fork-only (e.g. `text_to_schematic.py`, `sexpr_handler.py`, `visualization_tools.py`, `circuit_tools.py`), preventing wasted effort on changes that depend on unmerged predecessor features.

**`prepare-branch.sh <topic-slug> <sha>`** — clean-tree precondition, runs eligibility, fetches upstream, creates `pr-upstream/<topic-slug>` from `upstream/main`, cherry-picks the commit, reports any conflicts.

**`SKILL.md`** — covers the judgment: when to invoke, commit-message scrubbing rules (strip local issue refs, Claude trailers, fork-specific tooling mentions), diff hygiene (no bundled formatter cleanups), and a PR body template aligned with upstream's structure.

`.claude/settings.json` allowlist updated so the scripts run without permission prompts.

## Testing Performed

Smoke-tested both scripts against known cases:

- `check-eligibility.sh 08588e7` (text-to-schematic parser fixes) → correctly reports 2 fork-only files, exits 1
- `check-eligibility.sh 62e1218` (the commit just PR'd upstream) → correctly reports eligible, exits 0
- `shellcheck` clean on both scripts

## Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings or errors