### PR TITLE
docs(user-stories): map MCP tools to personas and close top-3 test gaps

### DIFF
--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -1,0 +1,112 @@
+# KiCad MCP — User Stories & Test Coverage Map
+
+This document captures the user stories the KiCad MCP server is intended to
+support, mapped to the tools/resources that back them and the tests that
+verify them. It exists to:
+
+1. Make the *intended* behavior of each MCP tool reviewable as text.
+2. Highlight blind spots in test coverage so gaps can be triaged.
+3. Provide a stable target when adding new features or refactoring tools.
+
+When you add or change a tool, update the relevant story row(s) in the same
+PR. When you add a test that fills a gap, flip the coverage column.
+
+## Personas
+
+- **Hobbyist Designer** — bootstrapping small projects (LED drivers, MCU
+  boards) with low KiCad expertise; relies on the AI to generate scaffolding.
+- **Professional EE** — uses the AI to accelerate review, refactoring, and
+  documentation of existing designs; cares deeply about correctness.
+- **Educator / Learner** — explores designs, asks "what does this do?", and
+  builds tutorials.
+- **Manufacturing / Procurement** — needs BOMs, sourcing data, pre-fab
+  checks, and Gerber-style outputs.
+- **Hardware Reviewer / Auditor** — runs DRC, validates structure, and tracks
+  regressions across revisions.
+
+## Coverage legend
+
+- ✅ — direct test exercises the MCP tool entry point
+- ⚠️ — only an underlying utility is tested, not the tool itself
+- ❌ — no test coverage
+- — — not applicable (e.g. prompt-only flow)
+
+## Hobbyist Designer
+
+| ID | Story | Tools | Coverage |
+|----|-------|-------|----------|
+| H1 | Create a new KiCad project from a name + description | `create_new_project` | ✅ `tests/unit/tools/test_circuit_tools.py` |
+| H2 | Describe a circuit in YAML/Mermaid-style text and get a working schematic | `create_kicad_schematic_from_text` | ⚠️ parser only (`test_text_to_schematic_parsers.py`); no end-to-end |
+| H3 | Add a component (R, C, MCU…) at given coordinates | `add_component` | ✅ |
+| H4 | Add a power symbol (VCC/GND/+5V/+3V3) | `add_power_symbol` | ✅ |
+| H5 | Connect two points with a wire | `create_wire_connection` | ⚠️ minimal |
+| H6 | Open the generated project in KiCad | `open_project` | ❌ |
+| H7 | See a thumbnail of the schematic / PCB | `capture_schematic_screenshot`, `capture_pcb_screenshot`, `generate_pcb_thumbnail` | ❌ |
+
+## Professional EE
+
+| ID | Story | Tools | Coverage |
+|----|-------|-------|----------|
+| P1 | List every KiCad project under one or more search directories | `list_projects` | ❌ |
+| P2 | Inspect the file structure and metadata of a project | `get_project_structure` | ❌ |
+| P3 | Validate a project has the essential KiCad files | `validate_project` | ❌ |
+| P4 | Validate a schematic for missing values, unconnected pins, etc. | `validate_schematic` | ✅ |
+| P5 | Validate component placement against board boundaries | `validate_project_boundaries` | ✅ `test_validation_tools.py` |
+| P6 | Extract a netlist with component and net counts | `extract_schematic_netlist`, `extract_project_netlist` | ⚠️ parser only |
+| P7 | Find every connection touching a single component (e.g. U3) | `find_component_connections` | ❌ |
+| P8 | Categorize nets (power vs signal) and surface floating nets | `analyze_schematic_connections` | ❌ |
+| P9 | Export the schematic as SVG/PNG for documentation | `export_schematic_svg`, `convert_svg_to_png` | ❌ |
+
+## Educator / Learner
+
+| ID | Story | Tools / Prompts | Coverage |
+|----|-------|-----------------|----------|
+| L1 | Identify the major circuit blocks in a schematic (power, amp, filter, MCU…) | `identify_circuit_patterns`, `analyze_project_circuit_patterns` | ⚠️ recognizers tested, tool wrapper not |
+| L2 | Get a plain-language explanation of what a circuit does | `explain_circuit_function` prompt | — |
+| L3 | Compare two schematics side by side | `compare_circuit_patterns` prompt, `bom_comparison` prompt | — |
+
+## Manufacturing / Procurement
+
+| ID | Story | Tools / Prompts | Coverage |
+|----|-------|-----------------|----------|
+| M1 | Export a CSV BOM for a contract manufacturer | `export_bom_csv` | ❌ |
+| M2 | Analyze an existing BOM (counts, categories, cost) | `analyze_bom` | ❌ |
+| M3 | Generate a PCB thumbnail image for documentation | `generate_pcb_thumbnail`, `generate_project_thumbnail` | ❌ |
+| M4 | Walk through a pre-manufacturing checklist | `pcb_manufacturing_checklist` prompt | — |
+| M5 | Export Gerber and drill files | **— missing tool —** | gap |
+
+## Hardware Reviewer / Auditor
+
+| ID | Story | Tools | Coverage |
+|----|-------|-------|----------|
+| R1 | Run DRC on a PCB and surface violations | `run_drc_check` | ❌ |
+| R2 | View DRC trend over time (improving / degrading / stable) | `get_drc_history_tool` | ⚠️ history util tested, tool not |
+| R3 | Confirm generated files actually round-trip through `kicad-cli` | (implicit) | ⚠️ partial in `test_kicad_compatibility` |
+
+## Cross-cutting / Non-functional
+
+| ID | Story | Coverage |
+|----|-------|----------|
+| N1 | Path-traversal protection on all `*_path` parameters | ✅ `test_path_validator` |
+| N2 | `kicad-cli` subprocess execution is sandboxed | ✅ `test_secure_subprocess` |
+| N3 | Concurrent tool calls do not corrupt shared temp dirs | ⚠️ one integration test |
+| N4 | Generated S-expression files are byte-compatible with KiCad | ✅ `test_kicad_boolean_compatibility`, version freshness tests |
+
+## Top blind spots (ranked by user impact × likelihood of breaking)
+
+1. **DRC tool itself** (R1) — the headline auditor feature has zero behavior tests.
+2. **BOM export & analysis** (M1, M2) — manufacturing workflow is completely untested.
+3. **Project discovery** (P1, P2, P3) — first thing every persona does, no tests.
+4. **Pattern recognition tool wrappers** (L1) — recognizers tested, MCP tool not.
+5. **Netlist tool wrappers** (P6, P7, P8) — same shape: util tested, tool not.
+6. **Visualization pipeline** (H7, P9, M3) — SVG → PNG → Image return path untested end-to-end.
+7. **Text-to-schematic happy path** (H2) — parser tested, but "text in → openable .kicad_sch out" round-trip is missing.
+8. **Missing capability**: Gerber/drill export (M5) — listed as medium priority in `CLAUDE.md` but no tool exists yet.
+
+## How to update this file
+
+- Adding a new tool → add a row under the persona it primarily serves.
+- Adding a test that closes a gap → flip the coverage cell from ❌/⚠️ to ✅.
+- Removing a tool → strike through the row rather than delete, so the
+  history of intent is preserved in `git log`.
+- New personas should be rare; prefer reusing the five above.

--- a/tests/unit/tools/test_bom_tools.py
+++ b/tests/unit/tools/test_bom_tools.py
@@ -1,0 +1,314 @@
+"""Unit tests for bom_tools.py - BOM analysis and CSV export.
+
+Backs user stories M1 (export_bom_csv) and M2 (analyze_bom) from
+docs/USER_STORIES.md.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastmcp import FastMCP
+import pytest
+
+from kicad_mcp.tools.bom_tools import (
+    analyze_bom_data,
+    parse_bom_file,
+    register_bom_tools,
+)
+
+
+def _get_tool(mcp: FastMCP, name: str):
+    return mcp._tool_manager._tools[name].fn
+
+
+@pytest.fixture
+def mcp_with_bom_tools():
+    mcp = FastMCP("test")
+    register_bom_tools(mcp)
+    return mcp
+
+
+class TestRegistration:
+    def test_registers_expected_tools(self, mcp_with_bom_tools):
+        tools = set(mcp_with_bom_tools._tool_manager._tools)
+        assert {"analyze_bom", "export_bom_csv"} <= tools
+
+
+class TestParseBomFile:
+    """parse_bom_file is the core helper for analyze_bom; verify formats."""
+
+    def test_parses_kicad_csv(self, tmp_path):
+        f = tmp_path / "bom.csv"
+        f.write_text(
+            "Reference,Value,Footprint,Quantity\nR1,10k,0805,1\nC1,100nF,0603,1\nU1,ESP32,QFN48,1\n"
+        )
+        components, info = parse_bom_file(str(f))
+
+        assert len(components) == 3
+        assert info["detected_format"] == "kicad"
+        assert info["delimiter"] == ","
+        assert components[0]["Reference"] == "R1"
+
+    def test_parses_semicolon_csv(self, tmp_path):
+        f = tmp_path / "euro.csv"
+        f.write_text("Reference;Value\nR1;10k\nR2;1k\n")
+        components, info = parse_bom_file(str(f))
+
+        assert len(components) == 2
+        assert info["delimiter"] == ";"
+
+    def test_parses_json_list_format(self, tmp_path):
+        f = tmp_path / "bom.json"
+        f.write_text('[{"reference": "R1", "value": "10k"}]')
+        components, info = parse_bom_file(str(f))
+
+        assert components == [{"reference": "R1", "value": "10k"}]
+        assert info["detected_format"] == "json"
+
+    def test_parses_json_components_key(self, tmp_path):
+        f = tmp_path / "bom.json"
+        f.write_text('{"components": [{"reference": "C1", "value": "100nF"}]}')
+        components, _ = parse_bom_file(str(f))
+
+        assert len(components) == 1
+        assert components[0]["reference"] == "C1"
+
+    def test_unknown_extension_falls_back_to_csv(self, tmp_path):
+        f = tmp_path / "weird.txt"
+        f.write_text("Reference,Value\nR1,10k\n")
+        components, info = parse_bom_file(str(f))
+
+        assert len(components) == 1
+        assert info["detected_format"] == "unknown_csv"
+
+
+class TestAnalyzeBomData:
+    """analyze_bom_data turns parsed rows into the summary the user sees."""
+
+    def test_categorizes_by_reference_prefix(self):
+        rows = [
+            {"reference": "R1", "value": "10k"},
+            {"reference": "R2", "value": "1k"},
+            {"reference": "C1", "value": "100nF"},
+            {"reference": "U1", "value": "ESP32"},
+        ]
+        result = analyze_bom_data(rows, {"detected_format": "kicad"})
+
+        assert result["unique_component_count"] == 4
+        assert result["total_component_count"] == 4
+        # Prefixes are mapped to friendly category names
+        assert result["categories"].get("Resistors") == 2
+        assert result["categories"].get("Capacitors") == 1
+        assert result["categories"].get("ICs") == 1
+
+    def test_quantity_column_is_summed(self):
+        rows = [
+            {"reference": "R1", "value": "10k", "quantity": "5"},
+            {"reference": "C1", "value": "100nF", "quantity": "3"},
+        ]
+        result = analyze_bom_data(rows, {})
+
+        assert result["total_component_count"] == 8
+        assert result["unique_component_count"] == 2
+
+    def test_cost_column_is_summed_with_currency(self):
+        rows = [
+            {"reference": "R1", "value": "10k", "quantity": "2", "cost": "$0.10"},
+            {"reference": "C1", "value": "100nF", "quantity": "4", "cost": "$0.05"},
+        ]
+        result = analyze_bom_data(rows, {})
+
+        assert result["has_cost_data"] is True
+        # 2 * 0.10 + 4 * 0.05 = 0.40
+        assert result["total_cost"] == pytest.approx(0.40)
+        assert result["currency"] == "USD"
+
+    def test_empty_input_returns_zero_counts(self):
+        result = analyze_bom_data([], {})
+
+        assert result["unique_component_count"] == 0
+        assert result["total_component_count"] == 0
+
+
+class TestAnalyzeBom:
+    """Story M2: end-to-end BOM analysis tool."""
+
+    @pytest.mark.asyncio
+    async def test_missing_project_returns_error(self, mcp_with_bom_tools, mock_context):
+        analyze_bom = _get_tool(mcp_with_bom_tools, "analyze_bom")
+
+        result = await analyze_bom(project_path="/no/such.kicad_pro", ctx=mock_context)
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_bom_files_returns_helpful_error(
+        self, mcp_with_bom_tools, mock_context, sample_kicad_project
+    ):
+        analyze_bom = _get_tool(mcp_with_bom_tools, "analyze_bom")
+
+        result = await analyze_bom(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is False
+        assert "bom" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_analyzes_csv_bom_next_to_project(
+        self, mcp_with_bom_tools, mock_context, sample_kicad_project
+    ):
+        # Drop a sibling BOM that get_project_files will discover.
+        from pathlib import Path
+
+        project_dir = Path(sample_kicad_project["directory"])
+        project_name = sample_kicad_project["name"]
+        bom_file = project_dir / f"{project_name}-bom.csv"
+        bom_file.write_text("Reference,Value,Quantity\nR1,10k,2\nC1,100nF,4\nU1,ESP32,1\n")
+
+        analyze_bom = _get_tool(mcp_with_bom_tools, "analyze_bom")
+        result = await analyze_bom(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is True
+        assert result["component_summary"]["total_components"] == 7
+        assert result["component_summary"]["total_unique_components"] == 3
+        # Progress was reported
+        mock_context.report_progress.assert_called()
+
+
+class TestExportBomCsv:
+    """Story M1: export a CSV BOM via kicad-cli."""
+
+    @pytest.mark.asyncio
+    async def test_missing_project_returns_error(self, mcp_with_bom_tools, mock_context):
+        export = _get_tool(mcp_with_bom_tools, "export_bom_csv")
+
+        result = await export(project_path="/no/such.kicad_pro", ctx=mock_context)
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_schematic_returns_error(
+        self, mcp_with_bom_tools, mock_context, tmp_path
+    ):
+        # Project file exists, but there is no sibling .kicad_sch
+        pro = tmp_path / "noSch.kicad_pro"
+        pro.write_text("{}")
+
+        export = _get_tool(mcp_with_bom_tools, "export_bom_csv")
+        result = await export(project_path=str(pro), ctx=mock_context)
+
+        assert result["success"] is False
+        assert "schematic" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_export_via_cli(
+        self, mcp_with_bom_tools, mock_context, sample_kicad_project
+    ):
+        export = _get_tool(mcp_with_bom_tools, "export_bom_csv")
+
+        async def fake_export(schematic_file, output_dir, project_name, ctx):
+            output_file = f"{output_dir}/{project_name}_bom.csv"
+            # Simulate kicad-cli writing the file
+            with open(output_file, "w") as f:
+                f.write("Reference,Value\nR1,10k\n")
+            return {
+                "success": True,
+                "output_file": output_file,
+                "schematic_file": schematic_file,
+                "file_size": 24,
+                "message": "BOM exported successfully",
+            }
+
+        with patch(
+            "kicad_mcp.tools.bom_tools.export_bom_with_cli", side_effect=fake_export
+        ) as mock_export:
+            result = await export(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is True
+        assert result["output_file"].endswith("_bom.csv")
+        mock_export.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cli_failure_is_propagated(
+        self, mcp_with_bom_tools, mock_context, sample_kicad_project
+    ):
+        export = _get_tool(mcp_with_bom_tools, "export_bom_csv")
+
+        with patch(
+            "kicad_mcp.tools.bom_tools.export_bom_with_cli",
+            new=AsyncMock(return_value={"success": False, "error": "kicad-cli not found"}),
+        ):
+            result = await export(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is False
+        assert "kicad-cli" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_cli_exception_is_caught(
+        self, mcp_with_bom_tools, mock_context, sample_kicad_project
+    ):
+        """If export_bom_with_cli raises, the tool should still return a dict, not crash."""
+        export = _get_tool(mcp_with_bom_tools, "export_bom_csv")
+
+        with patch(
+            "kicad_mcp.tools.bom_tools.export_bom_with_cli",
+            new=AsyncMock(side_effect=OSError("disk full")),
+        ):
+            result = await export(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is False
+        assert "disk full" in result["error"]
+
+
+class TestExportBomWithCli:
+    """The lower-level CLI wrapper - verify it shells out via the secure runner."""
+
+    @pytest.mark.asyncio
+    async def test_runs_kicad_command_and_returns_success(self, tmp_path, mock_context):
+        from kicad_mcp.tools.bom_tools import export_bom_with_cli
+
+        schematic = tmp_path / "p.kicad_sch"
+        schematic.write_text("(kicad_sch)")
+        output_path = tmp_path / "p_bom.csv"
+
+        fake_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+        fake_runner = MagicMock()
+        fake_runner.run_kicad_command.return_value = fake_proc
+
+        def write_output(*args, **kwargs):
+            output_path.write_text("Reference,Value\nR1,10k\n")
+            return fake_proc
+
+        fake_runner.run_kicad_command.side_effect = write_output
+
+        with patch(
+            "kicad_mcp.utils.secure_subprocess.get_subprocess_runner",
+            return_value=fake_runner,
+        ):
+            result = await export_bom_with_cli(str(schematic), str(tmp_path), "p", mock_context)
+
+        assert result["success"] is True
+        assert result["output_file"] == str(output_path)
+        assert result["file_size"] > 0
+        fake_runner.run_kicad_command.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_nonzero_return_code_is_failure(self, tmp_path, mock_context):
+        from kicad_mcp.tools.bom_tools import export_bom_with_cli
+
+        schematic = tmp_path / "p.kicad_sch"
+        schematic.write_text("(kicad_sch)")
+
+        fake_runner = MagicMock()
+        fake_runner.run_kicad_command.return_value = MagicMock(
+            returncode=1, stdout="", stderr="boom"
+        )
+
+        with patch(
+            "kicad_mcp.utils.secure_subprocess.get_subprocess_runner",
+            return_value=fake_runner,
+        ):
+            result = await export_bom_with_cli(str(schematic), str(tmp_path), "p", mock_context)
+
+        assert result["success"] is False
+        assert "boom" in result["error"]

--- a/tests/unit/tools/test_drc_tools.py
+++ b/tests/unit/tools/test_drc_tools.py
@@ -1,0 +1,239 @@
+"""Unit tests for drc_tools.py - DRC execution and history.
+
+Backs user stories R1 (run_drc_check) and R2 (get_drc_history_tool)
+from docs/USER_STORIES.md.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from fastmcp import FastMCP
+import pytest
+
+from kicad_mcp.tools.drc_tools import register_drc_tools
+
+
+def _get_tool(mcp: FastMCP, name: str):
+    return mcp._tool_manager._tools[name].fn
+
+
+@pytest.fixture
+def mcp_with_drc_tools():
+    mcp = FastMCP("test")
+    register_drc_tools(mcp)
+    return mcp
+
+
+class TestRegistration:
+    def test_registers_expected_tools(self, mcp_with_drc_tools):
+        tools = set(mcp_with_drc_tools._tool_manager._tools)
+        assert {"run_drc_check", "get_drc_history_tool"} <= tools
+
+
+class TestGetDrcHistoryTool:
+    """Story R2: surface DRC trend over time."""
+
+    def test_missing_project_returns_error(self, mcp_with_drc_tools):
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+
+        result = get_history(project_path="/no/such.kicad_pro")
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_no_history_returns_empty_list_with_no_trend(
+        self, mcp_with_drc_tools, sample_kicad_project
+    ):
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+
+        with patch("kicad_mcp.tools.drc_tools.get_drc_history", return_value=[]):
+            result = get_history(project_path=sample_kicad_project["path"])
+
+        assert result["success"] is True
+        assert result["entry_count"] == 0
+        assert result["trend"] is None
+        assert result["history_entries"] == []
+
+    def test_single_entry_has_no_trend(self, mcp_with_drc_tools, sample_kicad_project):
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+        entries = [{"timestamp": 100.0, "datetime": "2026-05-01 00:00:00", "total_violations": 5}]
+
+        with patch("kicad_mcp.tools.drc_tools.get_drc_history", return_value=entries):
+            result = get_history(project_path=sample_kicad_project["path"])
+
+        assert result["entry_count"] == 1
+        assert result["trend"] is None
+
+    def test_improving_trend_when_violations_decrease(
+        self, mcp_with_drc_tools, sample_kicad_project
+    ):
+        # Entries are returned newest-first by get_drc_history, so the tool
+        # treats history[0] as "latest" and history[-1] as "earliest".
+        entries = [
+            {"timestamp": 200.0, "total_violations": 2},  # newest
+            {"timestamp": 150.0, "total_violations": 5},
+            {"timestamp": 100.0, "total_violations": 10},  # oldest
+        ]
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+
+        with patch("kicad_mcp.tools.drc_tools.get_drc_history", return_value=entries):
+            result = get_history(project_path=sample_kicad_project["path"])
+
+        assert result["trend"] == "improving"
+        assert result["entry_count"] == 3
+
+    def test_degrading_trend_when_violations_increase(
+        self, mcp_with_drc_tools, sample_kicad_project
+    ):
+        entries = [
+            {"timestamp": 200.0, "total_violations": 12},  # newest
+            {"timestamp": 100.0, "total_violations": 3},  # oldest
+        ]
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+
+        with patch("kicad_mcp.tools.drc_tools.get_drc_history", return_value=entries):
+            result = get_history(project_path=sample_kicad_project["path"])
+
+        assert result["trend"] == "degrading"
+
+    def test_stable_trend_when_violations_unchanged(self, mcp_with_drc_tools, sample_kicad_project):
+        entries = [
+            {"timestamp": 200.0, "total_violations": 4},
+            {"timestamp": 100.0, "total_violations": 4},
+        ]
+        get_history = _get_tool(mcp_with_drc_tools, "get_drc_history_tool")
+
+        with patch("kicad_mcp.tools.drc_tools.get_drc_history", return_value=entries):
+            result = get_history(project_path=sample_kicad_project["path"])
+
+        assert result["trend"] == "stable"
+
+
+class TestRunDrcCheck:
+    """Story R1: run DRC and surface violations."""
+
+    @pytest.mark.asyncio
+    async def test_missing_project_returns_error(self, mcp_with_drc_tools, mock_context):
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+
+        result = await run_drc(project_path="/no/such.kicad_pro", ctx=mock_context)
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_pcb_returns_error(self, mcp_with_drc_tools, mock_context, tmp_path):
+        # Project file with no sibling .kicad_pcb
+        pro = tmp_path / "noPcb.kicad_pro"
+        pro.write_text("{}")
+
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+        result = await run_drc(project_path=str(pro), ctx=mock_context)
+
+        assert result["success"] is False
+        assert "pcb" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_run_saves_history_and_reports_progress(
+        self, mcp_with_drc_tools, mock_context, sample_kicad_project
+    ):
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+        drc_payload = {
+            "success": True,
+            "total_violations": 0,
+            "violation_categories": {},
+            "violations": [],
+        }
+
+        with (
+            patch(
+                "kicad_mcp.tools.drc_tools.run_drc_via_cli",
+                new=AsyncMock(return_value=drc_payload),
+            ) as mock_cli,
+            patch("kicad_mcp.tools.drc_tools.save_drc_result") as mock_save,
+            patch("kicad_mcp.tools.drc_tools.compare_with_previous", return_value=None),
+        ):
+            result = await run_drc(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is True
+        assert result["total_violations"] == 0
+        # Underlying CLI was invoked with the discovered PCB path
+        mock_cli.assert_awaited_once()
+        called_pcb_arg = mock_cli.await_args.args[0]
+        assert called_pcb_arg == sample_kicad_project["pcb"]
+        # Successful runs are persisted to history
+        mock_save.assert_called_once()
+        # Progress reported at start and end
+        assert mock_context.report_progress.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_comparison_with_previous_run_is_attached(
+        self, mcp_with_drc_tools, mock_context, sample_kicad_project
+    ):
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+        comparison = {
+            "current_violations": 1,
+            "previous_violations": 3,
+            "change": -2,
+            "previous_datetime": "2026-05-01 00:00:00",
+            "new_categories": {},
+            "resolved_categories": {"clearance": 2},
+            "changed_categories": {},
+        }
+
+        with (
+            patch(
+                "kicad_mcp.tools.drc_tools.run_drc_via_cli",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "total_violations": 1,
+                        "violation_categories": {"clearance": 1},
+                    }
+                ),
+            ),
+            patch("kicad_mcp.tools.drc_tools.save_drc_result"),
+            patch(
+                "kicad_mcp.tools.drc_tools.compare_with_previous",
+                return_value=comparison,
+            ),
+        ):
+            result = await run_drc(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["comparison"] == comparison
+        # The tool should send a user-facing message celebrating the improvement
+        info_calls = [c.args[0] for c in mock_context.info.call_args_list if c.args]
+        assert any("fixed" in msg.lower() for msg in info_calls)
+
+    @pytest.mark.asyncio
+    async def test_failed_drc_does_not_save_history(
+        self, mcp_with_drc_tools, mock_context, sample_kicad_project
+    ):
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+        failure = {"success": False, "error": "kicad-cli not found"}
+
+        with (
+            patch(
+                "kicad_mcp.tools.drc_tools.run_drc_via_cli",
+                new=AsyncMock(return_value=failure),
+            ),
+            patch("kicad_mcp.tools.drc_tools.save_drc_result") as mock_save,
+        ):
+            result = await run_drc(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result == failure
+        mock_save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_result_falls_back_to_generic_failure(
+        self, mcp_with_drc_tools, mock_context, sample_kicad_project
+    ):
+        run_drc = _get_tool(mcp_with_drc_tools, "run_drc_check")
+
+        with patch(
+            "kicad_mcp.tools.drc_tools.run_drc_via_cli",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await run_drc(project_path=sample_kicad_project["path"], ctx=mock_context)
+
+        assert result["success"] is False
+        assert "unknown" in result["error"].lower()

--- a/tests/unit/tools/test_project_tools.py
+++ b/tests/unit/tools/test_project_tools.py
@@ -1,0 +1,231 @@
+"""Unit tests for project_tools.py - project discovery, structure, and open.
+
+Backs user stories P1 (list_projects), P2 (get_project_structure),
+H6 (open_project), and P3 (validate_project) from docs/USER_STORIES.md.
+"""
+
+from unittest.mock import patch
+
+from fastmcp import FastMCP
+import pytest
+
+from kicad_mcp.tools.analysis_tools import register_analysis_tools
+from kicad_mcp.tools.project_tools import register_project_tools
+
+
+def _get_tool(mcp: FastMCP, name: str):
+    """Pull a registered tool's underlying function out of FastMCP."""
+    return mcp._tool_manager._tools[name].fn
+
+
+class TestRegistration:
+    def test_register_project_tools_registers_expected_names(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+
+        tools = set(mcp._tool_manager._tools)
+        assert {"list_projects", "get_project_structure", "open_project"} <= tools
+
+
+class TestListProjects:
+    """Story P1: list every KiCad project under one or more search dirs."""
+
+    def test_default_search_uses_find_kicad_projects(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        list_projects = _get_tool(mcp, "list_projects")
+
+        sample = [{"name": "alpha", "path": "/a/alpha.kicad_pro"}]
+        with (
+            patch(
+                "kicad_mcp.tools.project_tools.find_kicad_projects", return_value=sample
+            ) as mock_default,
+            patch("kicad_mcp.tools.project_tools.find_kicad_projects_in_dirs") as mock_dirs,
+        ):
+            result = list_projects(search_directories=None)
+
+        assert result == sample
+        mock_default.assert_called_once_with()
+        mock_dirs.assert_not_called()
+
+    def test_custom_search_directories_are_forwarded(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        list_projects = _get_tool(mcp, "list_projects")
+
+        dirs = ["/tmp/projects", "/opt/work"]
+        sample = [
+            {"name": "beta", "path": "/tmp/projects/beta.kicad_pro"},
+            {"name": "gamma", "path": "/opt/work/gamma.kicad_pro"},
+        ]
+        with (
+            patch(
+                "kicad_mcp.tools.project_tools.find_kicad_projects_in_dirs",
+                return_value=sample,
+            ) as mock_dirs,
+            patch("kicad_mcp.tools.project_tools.find_kicad_projects") as mock_default,
+        ):
+            result = list_projects(search_directories=dirs)
+
+        assert result == sample
+        mock_dirs.assert_called_once_with(dirs)
+        mock_default.assert_not_called()
+
+    def test_empty_directory_list_falls_through_to_default(self):
+        """An empty list is falsy, so the tool should fall back to defaults."""
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        list_projects = _get_tool(mcp, "list_projects")
+
+        with (
+            patch(
+                "kicad_mcp.tools.project_tools.find_kicad_projects", return_value=[]
+            ) as mock_default,
+            patch("kicad_mcp.tools.project_tools.find_kicad_projects_in_dirs") as mock_dirs,
+        ):
+            result = list_projects(search_directories=[])
+
+        assert result == []
+        mock_default.assert_called_once()
+        mock_dirs.assert_not_called()
+
+
+class TestGetProjectStructure:
+    """Story P2: inspect the file structure and metadata of a project."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_structure_for_existing_project(self, sample_kicad_project):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        get_structure = _get_tool(mcp, "get_project_structure")
+
+        result = get_structure(project_path=sample_kicad_project["path"])
+
+        assert result["name"] == sample_kicad_project["name"]
+        assert result["path"] == sample_kicad_project["path"]
+        assert result["directory"] == sample_kicad_project["directory"]
+        assert "files" in result
+        # The fixture creates schematic + pcb + project files
+        assert "project" in result["files"]
+        assert "schematic" in result["files"]
+        assert "pcb" in result["files"]
+        # Metadata is optional in the fixture (pyproject doesn't write a `metadata` block),
+        # so just assert the key exists
+        assert "metadata" in result
+
+    def test_returns_error_for_nonexistent_path(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        get_structure = _get_tool(mcp, "get_project_structure")
+
+        result = get_structure(project_path="/no/such/place.kicad_pro")
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_metadata_is_extracted_when_present(self, tmp_path):
+        """If the .kicad_pro contains a metadata block, it should be surfaced."""
+        import json
+
+        project_dir = tmp_path / "with_meta"
+        project_dir.mkdir()
+        pro = project_dir / "with_meta.kicad_pro"
+        pro.write_text(json.dumps({"metadata": {"author": "test", "revision": "A"}, "meta": {}}))
+        # Empty schematic + pcb so file discovery has something to find
+        (project_dir / "with_meta.kicad_sch").write_text("(kicad_sch)")
+        (project_dir / "with_meta.kicad_pcb").write_text("(kicad_pcb)")
+
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        get_structure = _get_tool(mcp, "get_project_structure")
+
+        result = get_structure(project_path=str(pro))
+
+        assert result["metadata"] == {"author": "test", "revision": "A"}
+
+
+class TestOpenProject:
+    """Story H6: open a generated project in KiCad."""
+
+    def test_delegates_to_open_kicad_project(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        open_project = _get_tool(mcp, "open_project")
+
+        expected = {"success": True, "message": "Opened in KiCad"}
+        with patch(
+            "kicad_mcp.tools.project_tools.open_kicad_project", return_value=expected
+        ) as mock_open:
+            result = open_project(project_path="/some/project.kicad_pro")
+
+        assert result == expected
+        mock_open.assert_called_once_with("/some/project.kicad_pro")
+
+    def test_propagates_failure_dict(self):
+        mcp = FastMCP("test")
+        register_project_tools(mcp)
+        open_project = _get_tool(mcp, "open_project")
+
+        failure = {"success": False, "error": "KiCad not installed"}
+        with patch("kicad_mcp.tools.project_tools.open_kicad_project", return_value=failure):
+            result = open_project(project_path="/some/project.kicad_pro")
+
+        assert result == failure
+
+
+class TestValidateProject:
+    """Story P3: validate that a project has the essential KiCad files."""
+
+    def test_valid_project_has_no_issues(self, sample_kicad_project):
+        mcp = FastMCP("test")
+        register_analysis_tools(mcp)
+        validate = _get_tool(mcp, "validate_project")
+
+        result = validate(project_path=sample_kicad_project["path"])
+
+        assert result["valid"] is True
+        assert result["issues"] is None
+        assert "schematic" in result["files_found"]
+        assert "pcb" in result["files_found"]
+
+    def test_missing_path_returns_error(self):
+        mcp = FastMCP("test")
+        register_analysis_tools(mcp)
+        validate = _get_tool(mcp, "validate_project")
+
+        result = validate(project_path="/does/not/exist.kicad_pro")
+
+        assert result["valid"] is False
+        assert "error" in result
+
+    def test_missing_pcb_and_schematic_are_reported(self, tmp_path):
+        """A .kicad_pro file alone (no .kicad_sch / .kicad_pcb) should fail validation."""
+        pro = tmp_path / "lonely.kicad_pro"
+        pro.write_text("{}")  # Valid JSON but no siblings
+
+        mcp = FastMCP("test")
+        register_analysis_tools(mcp)
+        validate = _get_tool(mcp, "validate_project")
+
+        result = validate(project_path=str(pro))
+
+        assert result["valid"] is False
+        issues = result["issues"]
+        assert any("schematic" in issue.lower() for issue in issues)
+        assert any("pcb" in issue.lower() for issue in issues)
+
+    def test_invalid_json_is_reported(self, tmp_path):
+        pro = tmp_path / "bad.kicad_pro"
+        pro.write_text("{ this is not valid json")
+        # Sibling files so PCB/schematic checks pass
+        (tmp_path / "bad.kicad_sch").write_text("(kicad_sch)")
+        (tmp_path / "bad.kicad_pcb").write_text("(kicad_pcb)")
+
+        mcp = FastMCP("test")
+        register_analysis_tools(mcp)
+        validate = _get_tool(mcp, "validate_project")
+
+        result = validate(project_path=str(pro))
+
+        assert result["valid"] is False
+        assert any("json" in issue.lower() for issue in result["issues"])


### PR DESCRIPTION
## Summary

- Add `docs/USER_STORIES.md` mapping every MCP tool to the persona it serves, along with the current test-coverage state of each story. Use it as a living triage doc.
- Close the three highest-impact gaps surfaced by that map:
  - `tests/unit/tools/test_project_tools.py` — `list_projects`, `get_project_structure`, `open_project`, plus `validate_project` from `analysis_tools` (stories P1, P2, H6, P3).
  - `tests/unit/tools/test_bom_tools.py` — `parse_bom_file`, `analyze_bom_data`, the `analyze_bom` and `export_bom_csv` MCP tools, and the lower-level `export_bom_with_cli` helper (M1, M2).
  - `tests/unit/tools/test_drc_tools.py` — `run_drc_check` happy path, history persistence, comparison-against-previous messaging, and all four trend states of `get_drc_history_tool` (R1, R2).
- Coverage rises from ~45% to ~50.6%; suite is 569 passed, 5 skipped (KiCad CLI unavailable in CI).

## Follow-up issues

Tracking the remaining gaps the story map identifies:

- #88 — test: cover `pattern_tools` MCP wrappers (story L1)
- #89 — test: cover `netlist_tools` MCP wrappers (stories P6, P7, P8)
- #90 — test: cover visualization & thumbnail rendering pipeline (stories H7, P9, M3)
- #91 — test: end-to-end round-trip for `create_kicad_schematic_from_text` (story H2)
- #92 — feat: add Gerber and drill file export tool (story M5 — capability gap)

## Test plan

- [x] `make lint` passes
- [x] `make format` is a no-op
- [x] `make test` passes with coverage ≥ 45% (50.6%)
- [x] CI green on PR (10/10 checks)

https://claude.ai/code/session_0115Dnam6nXCG9iKtjJ9V2dx