### PR TITLE
ci: adopt org reusable workflows and fix release-please auth

### DIFF
--- a/.github/workflows/clear-autorelease-labels.yml
+++ b/.github/workflows/clear-autorelease-labels.yml
@@ -1,0 +1,30 @@
+name: "Maintenance: clear autorelease labels"
+
+# Thin caller for the org reusable workflow. See
+# laurigates/.github/.github/workflows/reusable-clear-autorelease-labels.yml
+# for what this does and when to run it (manual escape hatch for a clogged
+# release-please pipeline — a merged release PR left labelled
+# "autorelease: pending" blocks every subsequent run).
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: "Label to strip from closed PRs"
+        default: "autorelease: pending"
+        required: false
+      dry_run:
+        description: "List matches without removing the label"
+        type: boolean
+        default: false
+
+jobs:
+  clear-labels:
+    uses: laurigates/.github/.github/workflows/reusable-clear-autorelease-labels.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      label: ${{ inputs.label }}
+      dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,0 +1,22 @@
+name: "PR: Enforce conventional commits"
+
+# Auto-fixes PR titles to the conventional-commits spec. This directly guards
+# the release-please pipeline: a squash-merged PR whose title is not a
+# conventional commit contributes no releasable commit, so the release is
+# silently skipped.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+# Explicit grant so the reusable workflow can edit PR titles even when the
+# repo's default workflow permissions are read-only.
+permissions:
+  pull-requests: write
+
+jobs:
+  conventional-commits:
+    uses: laurigates/.github/.github/workflows/reusable-enforce-conventional-commits.yml@main

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,49 @@
+name: Quality
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# Each push to a PR supersedes the previous review; don't pay for reviews of
+# code that has already been replaced.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Explicit grant so the reusable workflows get the token scopes they declare
+# (incl. id-token: write for OIDC) even when the repo's default workflow
+# permissions are read-only.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  code-smell:
+    # Two guards, both about jobs that would fail rather than tell us anything:
+    # these reusable workflows default `allowed-bots` to empty, so renovate and
+    # release-please PRs get rejected by claude-code-action; and a fork PR gets
+    # no secrets, so CLAUDE_CODE_OAUTH_TOKEN arrives empty.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: laurigates/.github/.github/workflows/reusable-quality-code-smell.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      # Reusable default is JS/TS; this is a Python project.
+      file-patterns: '**/*.py'
+
+  # Every MCP tool here is an async function, and a dropped `await` is the
+  # repo's demonstrated bug class — two of the queued upstream fixes are
+  # missing `await ctx.info()` calls that passed CI and review unnoticed.
+  async-patterns:
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: laurigates/.github/.github/workflows/reusable-quality-async.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      file-patterns: '**/*.py'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,20 +1,27 @@
+name: "Release: release-please"
+
 on:
   push:
     branches:
       - main
+  # Allow manual triggering, e.g. after the gitops apply lands the App
+  # credentials, or after a stale release PR is closed.
+  workflow_dispatch: {}
+
+# Concurrency lives in the reusable workflow (group release-please-<repo>,
+# cancel-in-progress: false). Declaring the same group here would have this run
+# hold the group while the workflow it calls queues behind it.
 
 permissions:
   contents: write
   pull-requests: write
 
-name: release-please
-
 jobs:
   release-please:
-    # Pure GitHub-API job (no build) — 1-CPU slim runner is 3x cheaper.
-    runs-on: ubuntu-slim
-    steps:
-      - uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          release-type: python
+    uses: laurigates/.github/.github/workflows/reusable-release-please.yml@main
+    with:
+      # gitops provisions the numeric App ID; the reusable workflow forwards it
+      # to create-github-app-token, which accepts it as the JWT issuer.
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,51 @@
+name: Renovate
+
+# NOTE: deliberately NOT on a schedule. The account's dependency updates come
+# from the single centralized autodiscover runner in `gitops`
+# (renovate_runner = true), which scans `laurigates/*` every two hours with an
+# owner-wide App token. A scheduled caller here would be a second Renovate
+# instance over the same repo, racing the first for the Dependency Dashboard
+# issue and the renovate/* branches.
+#
+# This caller exists as an on-demand escape hatch: it passes no `app-id`, so
+# the reusable workflow falls back to GITHUB_TOKEN and scans only this repo —
+# useful for a one-off lookup/dry-run without waiting for the central pass, or
+# for diagnosing why the central runner has not onboarded this repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run mode'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'full'
+          - 'lookup'
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+          - warn
+
+# Explicit grant so the run works even when the repo's default workflow
+# permissions are read-only (the reusable workflow needs write to open
+# dependency PRs and the Dependency Dashboard issue).
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  packages: read
+
+jobs:
+  renovate:
+    uses: laurigates/.github/.github/workflows/reusable-renovate.yml@main
+    with:
+      dry-run: ${{ inputs.dryRun || 'false' }}
+      log-level: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,56 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# Each push to a PR supersedes the previous scan; don't pay for reviews of
+# code that has already been replaced.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Explicit grant so the reusable workflows get the token scopes they declare
+# (incl. id-token: write for OIDC) even when the repo's default workflow
+# permissions are read-only.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  # This server shells out to the KiCad CLI and resolves user-supplied file
+  # paths, so command injection and path traversal are the live risks here —
+  # see CLAUDE.md § Security Considerations.
+  owasp:
+    # Two guards, both about jobs that would fail rather than tell us anything:
+    # these reusable workflows default `allowed-bots` to empty, so renovate and
+    # release-please PRs get rejected by claude-code-action; and a fork PR gets
+    # no secrets, so CLAUDE_CODE_OAUTH_TOKEN arrives empty.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: laurigates/.github/.github/workflows/reusable-security-owasp.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      # Pinned rather than inherited: upstream's default spans nine languages,
+      # of which only Python exists here.
+      file-patterns: '**/*.py'
+
+  secrets-scan:
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: laurigates/.github/.github/workflows/reusable-security-secrets.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      # Same as upstream's current default; pinned so this stays a whole-repo
+      # scan if that default ever narrows.
+      file-patterns: '**/*'
+
+# Dependency auditing is deliberately absent: ci.yml already runs `pip-audit`
+# and `bandit` inline against the uv-managed environment, and
+# reusable-security-deps.yml has no uv package-manager option.


### PR DESCRIPTION
## What

Migrates `release-please.yml` to the org reusable workflow and adopts the five reusable callers this repo was missing.

## Why

**release-please has failed on every run since at least 2026-04-28** with `Bad credentials`. No release has been cut since `v0.1.0` (2025-07-30).

The root cause is upstream of the workflow: `kicad-mcp` was never flagged `release_please = true` in `gitops/repositories.tf`, so it never received the GitHub App credentials every other managed repo uses. It was left authenticating with a bare `RELEASE_PLEASE_TOKEN` PAT dated **2025-07-17** — a year old, hence the rejection.

```
$ gh run list --workflow=release-please.yml -L 5
failure  2026-07-29
failure  2026-07-28
failure  2026-06-20  ×2
failure  2026-05-07

$ gh variable list -R laurigates/kicad-mcp
(empty — no RELEASE_PLEASE_APP_ID)
```

## Blocked on

**laurigates/gitops#257** — adds `release_please = true`, whose apply pushes `RELEASE_PLEASE_APP_ID` and `RELEASE_PLEASE_PRIVATE_KEY`.

This workflow stays red until that lands. That is a no-op wait (the pipeline is already failing), and `workflow_dispatch` is wired so the first run can be triggered the moment the credentials arrive.

## Changes

| Workflow | Change |
|---|---|
| `release-please.yml` | → `reusable-release-please.yml` with `app-id` + `APP_PRIVATE_KEY` |
| `enforce-conventional-commits.yml` | new |
| `quality.yml` | new — code-smell + async, both scoped `**/*.py` |
| `security.yml` | new — owasp (`**/*.py`) + secrets (`**/*`) |
| `clear-autorelease-labels.yml` | new — manual escape hatch |
| `renovate.yml` | new — `workflow_dispatch` only, **not** scheduled |

Notes on the judgment calls:

- **`quality-async` is not filler here.** Every MCP tool is an async function, and a dropped `await` is this repo's demonstrated bug class — two of the queued upstream fixes (`c59e89e`, `0ad42d5`) are missing `await ctx.info()` calls that passed CI *and* review unnoticed.
- **`renovate.yml` is deliberately unscheduled.** Dependency updates come from the centralized autodiscover runner in `gitops` (`renovate_runner = true`, scanning `laurigates/*` every two hours). A scheduled caller here would be a second Renovate instance racing the first for the Dependency Dashboard issue and `renovate/*` branches. It passes no `app-id`, so it falls back to `GITHUB_TOKEN` and scans only this repo — an on-demand escape hatch.
- **`ci.yml` left inline** — no reusable equivalent exists for the Python lint/test/build matrix.
- **No dependency-audit caller** — `ci.yml` already runs `pip-audit` and `bandit`, and `reusable-security-deps.yml` has no `uv` package-manager option.

The existing `release-please-config.json` and `.release-please-manifest.json` already sit at the paths the reusable defaults to, so no config change was needed.

## Verification

- All nine workflows pass `actionlint` (exit 0), and the repo's full pre-commit suite passed on commit.
- The wiring is proven operational on `pal-mcp-server`, which passes `RELEASE_PLEASE_APP_ID` into the same reusable's `app-id` input and cut `v10.4.1` successfully.
- All 15 checks pass, including the five new callers — they resolve, start, and complete.
- **This PR cannot prove the Claude-powered checks analyze anything.** They are green-but-inert here for a benign reason: `Get changed files` matched zero `**/*.py` files (this PR is workflow YAML only), so each reusable's own no-matching-files gate skipped the analysis step:

  ```
  success   Get changed files
  skipped   Claude Code Smell Analysis
  ```

  That is correct behaviour, not a misconfiguration — but it means the operational signal is **the first PR after merge that touches Python files**. `conventional-commits / Fix PR title` did genuinely execute (it is `github-script`, not `claude-code-action`), so that one is already proven.

## Follow-ups

- Manifest/pyproject drift: `.release-please-manifest.json` says `0.1.0` while `pyproject.toml` says `0.2.0` (hand-bumped at some point). release-please treats the manifest as truth and will rewrite `pyproject.toml` via `extra-files`, so this self-heals on the first release. Deliberately not hand-edited.
- The stale `RELEASE_PLEASE_TOKEN` secret should be deleted once a release succeeds via the App token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


